### PR TITLE
chore(app): adds gh workflows/actions to ignore security alerts

### DIFF
--- a/.github/SECURITY_BASELINE.md
+++ b/.github/SECURITY_BASELINE.md
@@ -1,0 +1,22 @@
+# Security Baseline
+
+## Expected Security Alerts
+
+The following directories contain intentional vulnerable code for demonstration and testing purposes:
+
+### `/demo/` Directory
+- **Purpose**: Contains demonstration code showing Pastoralist's security detection capabilities
+- **Expected Alerts**: Various npm/yarn/pnpm security vulnerabilities
+- **Justification**: These vulnerabilities are intentionally included to demonstrate how Pastoralist can detect and help fix security issues
+
+### `/e2e/fixtures/` Directory
+- **Purpose**: End-to-end testing fixtures with vulnerable packages
+- **Expected Alerts**: Known vulnerable dependencies used for testing
+- **Justification**: Required for testing security detection features
+
+## Review Guidelines
+
+When reviewing security alerts:
+1. Ignore alerts from `/demo/` and `/e2e/fixtures/` directories
+2. Focus on alerts in production code (`/src/`, root `package.json`)
+3. Any new vulnerabilities outside demo/test directories should be addressed immediately

--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,5 @@
+name: "CodeQL config"
+
+paths-ignore:
+  - demo/**
+  - e2e/fixtures/**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
       interval: daily
       time: "13:00"
     open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
+        # Ignore all updates in demo directories
+        directory: "/demo/**"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,6 +25,7 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql-config.yml
       - name: Autobuild
         uses: github/codeql-action/autobuild@v2
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
## Fixes

- Adds workflows/actions to hopefully cause security alerts to be ignore (b/c they're intentional)

---

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
