### PR TITLE
fix(workspace): address greptile review feedback

### DIFF
--- a/src/cli/security.ts
+++ b/src/cli/security.ts
@@ -138,7 +138,6 @@ export const determineSecurityScanPaths = (
   log: ReturnType<typeof createLogger> = logger,
 ): string[] => {
   const configDepPaths = config?.pastoralist?.depPaths;
-  const workspacePaths = resolveWorkspaceManifestPaths(config, mergedOptions.root || "./", log);
   const hasSecurityEnabled =
     mergedOptions.checkSecurity || config?.pastoralist?.checkSecurity || false;
 
@@ -150,6 +149,7 @@ export const determineSecurityScanPaths = (
     return configDepPaths;
   }
 
+  const workspacePaths = resolveWorkspaceManifestPaths(config, mergedOptions.root || "./", log);
   if (shouldScanWorkspaces(configDepPaths, workspacePaths, hasSecurityEnabled, mergedOptions)) {
     log.debug(
       `Using workspace configuration for security checks: ${workspacePaths.join(", ")}`,

--- a/src/core/workspace/index.ts
+++ b/src/core/workspace/index.ts
@@ -150,9 +150,7 @@ export const parsePnpmWorkspacePackages = (contents: string): string[] => {
     }
 
     const isOutsidePackagesBlock = indent <= packagesIndent;
-    const isListItem = trimmed.startsWith("-");
-    const reachedNextBlock = isOutsidePackagesBlock && !isListItem;
-    if (reachedNextBlock) break;
+    if (isOutsidePackagesBlock) break;
 
     const itemMatch = trimmed.match(/^-\s*(.+)$/);
     if (!itemMatch) continue;

--- a/tests/unit/cli/index.test.ts
+++ b/tests/unit/cli/index.test.ts
@@ -813,6 +813,43 @@ test("determineSecurityScanPaths - prioritizes depPaths array over workspace", (
   expect(result).toEqual(["custom/path/package.json"]);
 });
 
+test("determineSecurityScanPaths - skips workspace manifest read when depPaths array is used", () => {
+  const { determineSecurityScanPaths } = require("../../../src/cli/index");
+  const root = resolve(__dirname, "..", ".test-security-scan-paths");
+  const workspaceManifestPath = resolve(root, "pnpm-workspace.yaml");
+  const debug = mock(() => {});
+  const debugLog = { ...log, debug };
+
+  const config: PastoralistJSON = {
+    name: "test",
+    version: "1.0.0",
+    workspaces: ["packages/*"],
+    pastoralist: {
+      depPaths: ["custom/path/package.json"],
+      checkSecurity: true,
+    },
+  };
+
+  const mergedOptions: Options = {
+    checkSecurity: true,
+    hasWorkspaceSecurityChecks: true,
+    root,
+  };
+
+  try {
+    rmSync(root, { recursive: true, force: true });
+    mkdirSync(workspaceManifestPath, { recursive: true });
+
+    const result = determineSecurityScanPaths(config, mergedOptions, debugLog);
+
+    expect(result).toEqual(["custom/path/package.json"]);
+    expect(debug).toHaveBeenCalledTimes(1);
+    expect(debug.mock.calls[0][0]).toContain("Using depPaths configuration");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("buildMergedOptions - handles undefined config values", () => {
   const { buildMergedOptions } = require("../../../src/cli/index");
 

--- a/tests/unit/core/workspace/index.test.ts
+++ b/tests/unit/core/workspace/index.test.ts
@@ -82,6 +82,16 @@ test("parsePnpmWorkspacePackages - returns empty for missing or malformed packag
   expect(parsePnpmWorkspacePackages("packages: true")).toEqual([]);
 });
 
+test("parsePnpmWorkspacePackages - stops before same-indent list items outside packages", () => {
+  const result = parsePnpmWorkspacePackages(`
+packages:
+  - packages/*
+- not-a-package-workspace
+`);
+
+  expect(result).toEqual(["packages/*"]);
+});
+
 test("resolveWorkspaceManifestPaths - combines package.json and pnpm workspace sources", () => {
   const root = mkdtempSync(join(tmpdir(), "pastoralist-workspaces-"));
 


### PR DESCRIPTION
## Summary
- stop pnpm workspace parsing when a same-indent line leaves the packages block
- avoid reading workspace manifests when explicit depPaths are already configured
- add regression coverage for both Greptile findings

## Validation
- pre-commit checks passed: format, deps:check, build, app build, full unit tests