### PR TITLE
fix(release): skip existing prerelease tags

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -211,8 +211,9 @@ export function incrementPreReleaseVersion(version: string, preRelease: PreRelea
 
 export function releaseTagExists(runner: ReleaseRunner, tagName: string): boolean {
   const localTag = runner("git", ["rev-parse", "-q", "--verify", `refs/tags/${tagName}`]);
-  if (localTag.status !== 0 && localTag.stderr.trim()) {
-    throw new Error(localTag.stderr.trim() || `Unable to check local tag: ${tagName}`);
+  const localTagError = localTag.stderr.trim();
+  if (localTag.status !== 0 && localTagError) {
+    throw new Error(localTagError);
   }
   if (localTag.status === 0) return true;
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -18,6 +18,11 @@ export interface ReleaseArgs {
   preRelease?: PreRelease;
 }
 
+export interface ReleaseItArgsOptions {
+  preRelease?: PreRelease;
+  version?: string;
+}
+
 export interface ReleasePlan {
   commands: string[];
   steps: string[];
@@ -37,7 +42,7 @@ export function parseArgs(args: readonly string[]): ReleaseArgs {
   };
 }
 
-export function buildReleaseItArgs(options: Pick<ReleaseArgs, "preRelease">): string[] {
+export function buildReleaseItArgs(options: ReleaseItArgsOptions): string[] {
   const args = [
     "--git.tag=false",
     "--git.push=false",
@@ -45,7 +50,8 @@ export function buildReleaseItArgs(options: Pick<ReleaseArgs, "preRelease">): st
     "--git.getLatestTagFromAllRefs=true",
     "--ci",
   ];
-  return options.preRelease ? [`--preRelease=${options.preRelease}`, ...args] : args;
+  const releaseArgs = options.preRelease ? [`--preRelease=${options.preRelease}`, ...args] : args;
+  return options.version ? [options.version, ...releaseArgs] : releaseArgs;
 }
 
 export function parseReleaseVersion(output: string): string {
@@ -66,7 +72,10 @@ export function formatShellCommand(command: string, args: readonly string[]): st
 export function buildReleaseCommands(version: string, releaseArgs: ReleaseArgs): string[] {
   const tagName = `v${version}`;
   return [
-    formatShellCommand("./node_modules/.bin/release-it", buildReleaseItArgs(releaseArgs)),
+    formatShellCommand(
+      "./node_modules/.bin/release-it",
+      buildReleaseItArgs({ preRelease: releaseArgs.preRelease, version }),
+    ),
     formatShellCommand("git", ["tag", "--annotate", tagName, "--message", `Release ${version}`]),
     formatShellCommand("git", ["push", "origin", `refs/tags/${tagName}`]),
   ];
@@ -128,7 +137,7 @@ export async function runRelease(options: ReleaseOptions = {}): Promise<number> 
   }
 
   try {
-    createReleaseCommit(runner, releaseArgs);
+    createReleaseCommit(runner, releaseArgs, version);
     runReleaseTag({
       cwd,
       git: (args) => runner("git", args),
@@ -186,11 +195,60 @@ function resolveReleaseVersion(runner: ReleaseRunner, releaseArgs: ReleaseArgs):
     "--release-version",
     ...buildReleaseItArgs(releaseArgs),
   ]);
-  return parseReleaseVersion(output);
+  const version = parseReleaseVersion(output);
+  return resolveAvailableReleaseVersion(runner, releaseArgs, version);
 }
 
-function createReleaseCommit(runner: ReleaseRunner, releaseArgs: ReleaseArgs): void {
-  runCommand(runner, "./node_modules/.bin/release-it", buildReleaseItArgs(releaseArgs));
+export function incrementPreReleaseVersion(version: string, preRelease: PreRelease): string {
+  const pattern = new RegExp(`^(\\d+\\.\\d+\\.\\d+)-${preRelease}\\.(\\d+)(\\+[0-9A-Za-z.-]+)?$`);
+  const match = version.match(pattern);
+  if (!match) throw new Error(`Unable to advance ${preRelease} release version: ${version}`);
+
+  const nextPrerelease = Number(match[2]) + 1;
+  return `${match[1]}-${preRelease}.${nextPrerelease}${match[3] ?? ""}`;
+}
+
+export function releaseTagExists(runner: ReleaseRunner, tagName: string): boolean {
+  const localTag = runner("git", ["tag", "--list", tagName]);
+  if (localTag.status !== 0) {
+    throw new Error(localTag.stderr.trim() || `Unable to check local tag: ${tagName}`);
+  }
+  if (localTag.stdout.trim()) return true;
+
+  const remoteTag = runner("git", ["ls-remote", "--tags", "origin", `refs/tags/${tagName}`]);
+  if (remoteTag.status !== 0) {
+    throw new Error(remoteTag.stderr.trim() || `Unable to check remote tag: ${tagName}`);
+  }
+  return remoteTag.stdout.trim().length > 0;
+}
+
+export function resolveAvailableReleaseVersion(
+  runner: ReleaseRunner,
+  releaseArgs: ReleaseArgs,
+  version: string,
+): string {
+  if (!releaseArgs.preRelease) return version;
+
+  let candidate = version;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const tagName = `v${candidate}`;
+    if (!releaseTagExists(runner, tagName)) return candidate;
+    candidate = incrementPreReleaseVersion(candidate, releaseArgs.preRelease);
+  }
+
+  throw new Error(`Unable to find an available release tag for ${version}`);
+}
+
+function createReleaseCommit(
+  runner: ReleaseRunner,
+  releaseArgs: ReleaseArgs,
+  version: string,
+): void {
+  runCommand(
+    runner,
+    "./node_modules/.bin/release-it",
+    buildReleaseItArgs({ preRelease: releaseArgs.preRelease, version }),
+  );
 }
 
 function restoreStartingHead(runner: ReleaseRunner, startingHead: string): void {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -200,20 +200,21 @@ function resolveReleaseVersion(runner: ReleaseRunner, releaseArgs: ReleaseArgs):
 }
 
 export function incrementPreReleaseVersion(version: string, preRelease: PreRelease): string {
-  const pattern = new RegExp(`^(\\d+\\.\\d+\\.\\d+)-${preRelease}\\.(\\d+)(\\+[0-9A-Za-z.-]+)?$`);
-  const match = version.match(pattern);
-  if (!match) throw new Error(`Unable to advance ${preRelease} release version: ${version}`);
+  const match = version.match(/^(\d+\.\d+\.\d+)-([0-9A-Za-z.-]+)\.(\d+)(\+[0-9A-Za-z.-]+)?$/);
+  if (!match || match[2] !== preRelease) {
+    throw new Error(`Unable to advance ${preRelease} release version: ${version}`);
+  }
 
-  const nextPrerelease = Number(match[2]) + 1;
-  return `${match[1]}-${preRelease}.${nextPrerelease}${match[3] ?? ""}`;
+  const nextPrerelease = Number(match[3]) + 1;
+  return `${match[1]}-${preRelease}.${nextPrerelease}${match[4] ?? ""}`;
 }
 
 export function releaseTagExists(runner: ReleaseRunner, tagName: string): boolean {
-  const localTag = runner("git", ["tag", "--list", tagName]);
-  if (localTag.status !== 0) {
+  const localTag = runner("git", ["rev-parse", "-q", "--verify", `refs/tags/${tagName}`]);
+  if (localTag.status !== 0 && localTag.stderr.trim()) {
     throw new Error(localTag.stderr.trim() || `Unable to check local tag: ${tagName}`);
   }
-  if (localTag.stdout.trim()) return true;
+  if (localTag.status === 0) return true;
 
   const remoteTag = runner("git", ["ls-remote", "--tags", "origin", `refs/tags/${tagName}`]);
   if (remoteTag.status !== 0) {

--- a/tests/unit/scripts/release.test.ts
+++ b/tests/unit/scripts/release.test.ts
@@ -39,7 +39,7 @@ const readyOverrides = {
 };
 
 const missingTagOverrides = {
-  "git rev-parse -q --verify refs/tags/v1.2.4": fail("missing"),
+  "git rev-parse -q --verify refs/tags/v1.2.4": missing(),
   "git ls-remote --exit-code --tags origin refs/tags/v1.2.4": missing(),
 };
 

--- a/tests/unit/scripts/release.test.ts
+++ b/tests/unit/scripts/release.test.ts
@@ -44,7 +44,7 @@ const missingTagOverrides = {
 };
 
 const availableVersionOverrides = {
-  "git tag --list v1.2.4": ok(""),
+  "git rev-parse -q --verify refs/tags/v1.2.4": missing(),
   "git ls-remote --tags origin refs/tags/v1.2.4": ok(""),
 };
 
@@ -143,7 +143,7 @@ describe("scripts/release", () => {
     };
     const { calls, runner } = createRunner({
       ...readyOverrides,
-      "git tag --list v1.2.4-beta.6": ok(""),
+      "git rev-parse -q --verify refs/tags/v1.2.4-beta.6": missing(),
       "git ls-remote --tags origin refs/tags/v1.2.4-beta.6": ok(""),
       "./node_modules/.bin/release-it --release-version --preRelease=beta --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
         ok("1.2.4-beta.6\n"),
@@ -200,19 +200,28 @@ describe("scripts/release", () => {
 
   test("releaseTagExists checks local and remote tags", () => {
     const { runner } = createRunner({
-      "git tag --list v1.2.4-beta.7": ok(""),
+      "git rev-parse -q --verify refs/tags/v1.2.4-beta.7": missing(),
       "git ls-remote --tags origin refs/tags/v1.2.4-beta.7": ok("489e1e refs/tags/v1.2.4-beta.7\n"),
     });
 
     expect(releaseTagExists(runner, "v1.2.4-beta.7")).toBe(true);
   });
 
+  test("releaseTagExists returns false when local and remote tags are missing", () => {
+    const { runner } = createRunner({
+      "git rev-parse -q --verify refs/tags/v1.2.4-beta.7": missing(),
+      "git ls-remote --tags origin refs/tags/v1.2.4-beta.7": ok(""),
+    });
+
+    expect(releaseTagExists(runner, "v1.2.4-beta.7")).toBe(false);
+  });
+
   test("resolveAvailableReleaseVersion skips existing prerelease tags", () => {
     const { runner } = createRunner({
-      "git tag --list v1.2.4-beta.6": ok("v1.2.4-beta.6\n"),
-      "git tag --list v1.2.4-beta.7": ok(""),
+      "git rev-parse -q --verify refs/tags/v1.2.4-beta.6": ok("489e1e\n"),
+      "git rev-parse -q --verify refs/tags/v1.2.4-beta.7": missing(),
       "git ls-remote --tags origin refs/tags/v1.2.4-beta.7": ok("489e1e refs/tags/v1.2.4-beta.7\n"),
-      "git tag --list v1.2.4-beta.8": ok(""),
+      "git rev-parse -q --verify refs/tags/v1.2.4-beta.8": missing(),
       "git ls-remote --tags origin refs/tags/v1.2.4-beta.8": ok(""),
     });
 
@@ -232,9 +241,9 @@ describe("scripts/release", () => {
     };
     const { runner } = createRunner({
       ...readyOverrides,
-      "git tag --list v1.2.4-beta.6": ok(""),
+      "git rev-parse -q --verify refs/tags/v1.2.4-beta.6": missing(),
       "git ls-remote --tags origin refs/tags/v1.2.4-beta.6": ok("489e1e refs/tags/v1.2.4-beta.6\n"),
-      "git tag --list v1.2.4-beta.7": ok(""),
+      "git rev-parse -q --verify refs/tags/v1.2.4-beta.7": missing(),
       "git ls-remote --tags origin refs/tags/v1.2.4-beta.7": ok(""),
       "./node_modules/.bin/release-it --release-version --preRelease=beta --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
         ok("1.2.4-beta.6\n"),

--- a/tests/unit/scripts/release.test.ts
+++ b/tests/unit/scripts/release.test.ts
@@ -5,9 +5,12 @@ import {
   buildReleasePlan,
   formatReleasePlan,
   formatShellCommand,
+  incrementPreReleaseVersion,
   parseArgs,
   parseReleaseVersion,
   quoteShellArg,
+  releaseTagExists,
+  resolveAvailableReleaseVersion,
   runRelease,
   type ReleaseRunner,
 } from "../../../scripts/release";
@@ -40,6 +43,11 @@ const missingTagOverrides = {
   "git ls-remote --exit-code --tags origin refs/tags/v1.2.4": missing(),
 };
 
+const availableVersionOverrides = {
+  "git tag --list v1.2.4": ok(""),
+  "git ls-remote --tags origin refs/tags/v1.2.4": ok(""),
+};
+
 describe("scripts/release", () => {
   test("parseArgs reads release options", () => {
     expect(parseArgs(["--preRelease=beta", "--dry-run"])).toEqual({
@@ -54,6 +62,18 @@ describe("scripts/release", () => {
 
   test("buildReleaseItArgs disables tag push and upstream requirements", () => {
     expect(buildReleaseItArgs({ preRelease: "beta" })).toEqual([
+      "--preRelease=beta",
+      "--git.tag=false",
+      "--git.push=false",
+      "--git.requireUpstream=false",
+      "--git.getLatestTagFromAllRefs=true",
+      "--ci",
+    ]);
+  });
+
+  test("buildReleaseItArgs accepts an explicit release version", () => {
+    expect(buildReleaseItArgs({ preRelease: "beta", version: "1.2.4-beta.7" })).toEqual([
+      "1.2.4-beta.7",
       "--preRelease=beta",
       "--git.tag=false",
       "--git.push=false",
@@ -81,7 +101,7 @@ describe("scripts/release", () => {
 
   test("buildReleaseCommands returns the local release commands", () => {
     expect(buildReleaseCommands("1.2.4-beta.6", { dryRun: true, preRelease: "beta" })).toEqual([
-      "./node_modules/.bin/release-it --preRelease=beta --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci",
+      "./node_modules/.bin/release-it 1.2.4-beta.6 --preRelease=beta --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci",
       'git tag --annotate v1.2.4-beta.6 --message "Release 1.2.4-beta.6"',
       "git push origin refs/tags/v1.2.4-beta.6",
     ]);
@@ -90,7 +110,7 @@ describe("scripts/release", () => {
   test("buildReleasePlan returns the local release plan", () => {
     expect(buildReleasePlan("1.2.4-beta.6", { dryRun: true, preRelease: "beta" })).toEqual({
       commands: [
-        "./node_modules/.bin/release-it --preRelease=beta --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci",
+        "./node_modules/.bin/release-it 1.2.4-beta.6 --preRelease=beta --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci",
         'git tag --annotate v1.2.4-beta.6 --message "Release 1.2.4-beta.6"',
         "git push origin refs/tags/v1.2.4-beta.6",
       ],
@@ -123,6 +143,8 @@ describe("scripts/release", () => {
     };
     const { calls, runner } = createRunner({
       ...readyOverrides,
+      "git tag --list v1.2.4-beta.6": ok(""),
+      "git ls-remote --tags origin refs/tags/v1.2.4-beta.6": ok(""),
       "./node_modules/.bin/release-it --release-version --preRelease=beta --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
         ok("1.2.4-beta.6\n"),
     });
@@ -166,6 +188,70 @@ describe("scripts/release", () => {
     await expect(runRelease({ dryRun: true, runner })).rejects.toThrow("release-it failed");
   });
 
+  test("incrementPreReleaseVersion advances the prerelease number", () => {
+    expect(incrementPreReleaseVersion("1.2.4-beta.7", "beta")).toBe("1.2.4-beta.8");
+  });
+
+  test("incrementPreReleaseVersion rejects a mismatched prerelease", () => {
+    expect(() => incrementPreReleaseVersion("1.2.4-alpha.7", "beta")).toThrow(
+      "Unable to advance beta release version",
+    );
+  });
+
+  test("releaseTagExists checks local and remote tags", () => {
+    const { runner } = createRunner({
+      "git tag --list v1.2.4-beta.7": ok(""),
+      "git ls-remote --tags origin refs/tags/v1.2.4-beta.7": ok("489e1e refs/tags/v1.2.4-beta.7\n"),
+    });
+
+    expect(releaseTagExists(runner, "v1.2.4-beta.7")).toBe(true);
+  });
+
+  test("resolveAvailableReleaseVersion skips existing prerelease tags", () => {
+    const { runner } = createRunner({
+      "git tag --list v1.2.4-beta.6": ok("v1.2.4-beta.6\n"),
+      "git tag --list v1.2.4-beta.7": ok(""),
+      "git ls-remote --tags origin refs/tags/v1.2.4-beta.7": ok("489e1e refs/tags/v1.2.4-beta.7\n"),
+      "git tag --list v1.2.4-beta.8": ok(""),
+      "git ls-remote --tags origin refs/tags/v1.2.4-beta.8": ok(""),
+    });
+
+    expect(
+      resolveAvailableReleaseVersion(runner, { dryRun: true, preRelease: "beta" }, "1.2.4-beta.6"),
+    ).toBe("1.2.4-beta.8");
+  });
+
+  test("runRelease dry run advances past an existing prerelease tag", async () => {
+    let output = "";
+    const logger = {
+      error: mock(() => {}),
+      log: mock((message: string) => {
+        output = message;
+      }),
+      warn: mock(() => {}),
+    };
+    const { runner } = createRunner({
+      ...readyOverrides,
+      "git tag --list v1.2.4-beta.6": ok(""),
+      "git ls-remote --tags origin refs/tags/v1.2.4-beta.6": ok("489e1e refs/tags/v1.2.4-beta.6\n"),
+      "git tag --list v1.2.4-beta.7": ok(""),
+      "git ls-remote --tags origin refs/tags/v1.2.4-beta.7": ok(""),
+      "./node_modules/.bin/release-it --release-version --preRelease=beta --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
+        ok("1.2.4-beta.6\n"),
+    });
+
+    const code = await runRelease({
+      dryRun: true,
+      logger,
+      preRelease: "beta",
+      runner,
+    });
+
+    expect(code).toBe(0);
+    expect(output).toContain("Dry run release commands for v1.2.4-beta.7");
+    expect(output).toContain("./node_modules/.bin/release-it 1.2.4-beta.7 --preRelease=beta");
+  });
+
   test("runRelease creates a release commit and pushes the release tag", async () => {
     const logger = {
       error: mock(() => {}),
@@ -174,10 +260,11 @@ describe("scripts/release", () => {
     };
     const { calls, runner } = createRunner({
       ...readyOverrides,
+      ...availableVersionOverrides,
       ...missingTagOverrides,
       "./node_modules/.bin/release-it --release-version --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
         ok("1.2.4\n"),
-      "./node_modules/.bin/release-it --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
+      "./node_modules/.bin/release-it 1.2.4 --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
         ok(""),
       "git tag --annotate v1.2.4 --message Release 1.2.4": ok(""),
       "git push origin refs/tags/v1.2.4": ok(""),
@@ -200,10 +287,11 @@ describe("scripts/release", () => {
     };
     const { calls, runner } = createRunner({
       ...readyOverrides,
+      ...availableVersionOverrides,
       ...missingTagOverrides,
       "./node_modules/.bin/release-it --release-version --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
         ok("1.2.4\n"),
-      "./node_modules/.bin/release-it --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
+      "./node_modules/.bin/release-it 1.2.4 --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
         ok(""),
       "git tag --annotate v1.2.4 --message Release 1.2.4": ok(""),
       "git push origin refs/tags/v1.2.4": ok(""),
@@ -223,10 +311,11 @@ describe("scripts/release", () => {
     };
     const { calls, runner } = createRunner({
       ...readyOverrides,
+      ...availableVersionOverrides,
       ...missingTagOverrides,
       "./node_modules/.bin/release-it --release-version --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
         ok("1.2.4\n"),
-      "./node_modules/.bin/release-it --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
+      "./node_modules/.bin/release-it 1.2.4 --git.tag=false --git.push=false --git.requireUpstream=false --git.getLatestTagFromAllRefs=true --ci":
         ok(""),
       "git tag --annotate v1.2.4 --message Release 1.2.4": ok(""),
       "git push origin refs/tags/v1.2.4": fail("push rejected"),


### PR DESCRIPTION
## Summary
- skip prerelease versions whose tags already exist locally or on origin
- pass the resolved prerelease version explicitly into release-it and the release commit
- cover tag collision handling in release unit tests

## Validation
- bun test tests/unit/scripts/release.test.ts tests/unit/scripts/tag-release.test.ts
- bun run format
- bun run lint
- bun run build
- pre-commit hook full test suite passed