### PR TITLE
Attempt fix of bug for unresolved selectors

### DIFF
--- a/src/core/appendix/index.ts
+++ b/src/core/appendix/index.ts
@@ -34,6 +34,8 @@ import {
   shouldWriteAppendix,
   hasOverrides,
   mergeAppendixDependents,
+  parseOverridePackageName,
+  isResolvablePackageName,
 } from "./utils";
 
 const hasDependency = (deps: Record<string, string>, packageName: string): boolean =>
@@ -90,11 +92,19 @@ const isUnusedSimpleOverride = (
   const hasOverride = hasDependency(deps, override);
   if (hasOverride) return false;
 
+  // Resolve selector-syntax keys ("pkg@<range>", "parent>child") to the real package
+  // name, since the tree/graph are keyed by bare names. Without this, every such key
+  // misses every lookup and is falsely judged unused.
+  const name = parseOverridePackageName(override);
+
+  // Fail-safe: keep keys we cannot confidently resolve to a real package name.
+  if (!isResolvablePackageName(name)) return false;
+
   const depNames = new Set(Object.keys(deps));
-  const isRequiredByDependency = dependencyGraph?.[override]?.some((dep) => depNames.has(dep));
+  const isRequiredByDependency = dependencyGraph?.[name]?.some((dep) => depNames.has(dep));
   if (isRequiredByDependency) return false;
 
-  const isInDependencyTree = Boolean(dependencyTree?.[override]);
+  const isInDependencyTree = Boolean(dependencyTree?.[name]);
   return !isInDependencyTree;
 };
 

--- a/src/core/appendix/utils.ts
+++ b/src/core/appendix/utils.ts
@@ -261,6 +261,38 @@ export const mergeDependents = (
   return Object.assign({}, currentDependents, { [packageName]: dependentInfo });
 };
 
+const PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/i;
+
+/**
+ * Whether a string looks like a real npm package name. Used as a fail-safe: if an
+ * override key cannot be resolved to a plausible package name, the override is kept
+ * rather than risk deleting a load-bearing pin.
+ */
+export const isResolvablePackageName = (name: string): boolean => PACKAGE_NAME_PATTERN.test(name);
+
+/**
+ * Resolve a pnpm/yarn override *key* to the bare package name it actually pins, so it
+ * can be matched against the dependency tree/graph (both keyed by bare names).
+ *
+ *   "minimatch"            -> "minimatch"
+ *   "minimatch@<4"         -> "minimatch"
+ *   "minimatch@>=9 <10"    -> "minimatch"      (a range ">" is not a nesting separator)
+ *   "@scope/pkg@>=1 <2"    -> "@scope/pkg"
+ *   "gray-matter>js-yaml"  -> "js-yaml"         (nested: the pin is the child)
+ *   "foo@1>@scope/bar@<2"  -> "@scope/bar"
+ *
+ * Note: ">" is overloaded in pnpm keys — it separates "parent>child" *and* appears
+ * inside version ranges (">=9 <10"). A range ">" always immediately follows "@", so we
+ * only split on a ">" that is not preceded by "@".
+ */
+export const parseOverridePackageName = (overrideKey: string): string => {
+  const segments = overrideKey.split(/(?<!@)>/);
+  const target = (segments[segments.length - 1] ?? overrideKey).trim();
+  const lastAtIndex = target.lastIndexOf("@");
+  if (lastAtIndex <= 0) return target;
+  return target.slice(0, lastAtIndex);
+};
+
 export const buildDependentInfo = (
   hasOverride: boolean,
   override: string,
@@ -270,10 +302,17 @@ export const buildDependentInfo = (
 ): string => {
   if (hasOverride) return packageAtVersion(override)(packageVersion ?? "");
 
-  const requiredBy = dependencyGraph?.[override];
+  const name = parseOverridePackageName(override);
+
+  // Fail-safe: a key whose syntax we cannot resolve to a real package name is kept —
+  // deleting a load-bearing override is a security regression; keeping a stale one is
+  // merely cosmetic.
+  if (!isResolvablePackageName(name)) return `${override} (kept: unresolved override key)`;
+
+  const requiredBy = dependencyGraph?.[name];
   if (requiredBy?.length) return `${override} (required by ${requiredBy.slice(0, 3).join(", ")})`;
 
-  const isInDependencyTree = Boolean(dependencyTree?.[override]);
+  const isInDependencyTree = Boolean(dependencyTree?.[name]);
   if (isInDependencyTree) {
     return `${override} (transitive dependency)`;
   }

--- a/tests/unit/core/appendix/index.test.ts
+++ b/tests/unit/core/appendix/index.test.ts
@@ -115,6 +115,67 @@ test("updateAppendix - skips genuinely unused override when onlyUsedOverrides=tr
   expect(result["lodash@4.17.21"]).toBeUndefined();
 });
 
+// Regression: pnpm selector-syntax override keys ("pkg@<range>", "pkg@>=x <y",
+// "parent>child") were looked up in the dependency tree/graph using the *raw key*
+// instead of the real package name, so they were always judged "unused" and
+// stripped by --remove-unused — silently deleting load-bearing security pins.
+// See conversation "Remove unused pnpm overrides".
+test("updateAppendix - keeps selector-range override when package is in dependency tree (onlyUsedOverrides=true)", () => {
+  const overrides: OverridesType = { "minimatch@>=9 <10": "9.0.9" };
+  const result = updateAppendix({
+    overrides,
+    appendix: {},
+    dependencies: {},
+    devDependencies: {},
+    packageName: "root",
+    onlyUsedOverrides: true,
+    dependencyTree: { minimatch: true },
+  });
+  expect(result["minimatch@>=9 <10@9.0.9"]).toBeDefined();
+});
+
+test("updateAppendix - keeps selector-range override when required by a dependency (onlyUsedOverrides=true)", () => {
+  const overrides: OverridesType = { "minimatch@<4": "3.1.5" };
+  const result = updateAppendix({
+    overrides,
+    appendix: {},
+    dependencies: { glob: "^7.0.0" },
+    devDependencies: {},
+    packageName: "root",
+    onlyUsedOverrides: true,
+    dependencyGraph: { minimatch: ["glob"] },
+  });
+  expect(result["minimatch@<4@3.1.5"]).toBeDefined();
+});
+
+test("updateAppendix - keeps nested parent>child override when child is in dependency tree (onlyUsedOverrides=true)", () => {
+  const overrides: OverridesType = { "gray-matter>js-yaml": "3.14.2" };
+  const result = updateAppendix({
+    overrides,
+    appendix: {},
+    dependencies: {},
+    devDependencies: {},
+    packageName: "root",
+    onlyUsedOverrides: true,
+    dependencyTree: { "js-yaml": true },
+  });
+  expect(result["gray-matter>js-yaml@3.14.2"]).toBeDefined();
+});
+
+test("updateAppendix - still removes selector-range override when package is genuinely absent (onlyUsedOverrides=true)", () => {
+  const overrides: OverridesType = { "minimatch@>=9 <10": "9.0.9" };
+  const result = updateAppendix({
+    overrides,
+    appendix: {},
+    dependencies: {},
+    devDependencies: {},
+    packageName: "root",
+    onlyUsedOverrides: true,
+    dependencyTree: {},
+  });
+  expect(result["minimatch@>=9 <10@9.0.9"]).toBeUndefined();
+});
+
 test("updateAppendix - does not mutate original appendix", () => {
   const overrides: OverridesType = { lodash: "4.17.21" };
   const originalAppendix: Appendix = {

--- a/tests/unit/core/appendix/utils.test.ts
+++ b/tests/unit/core/appendix/utils.test.ts
@@ -12,6 +12,8 @@ import {
   normalizeLedgerCveField,
   isKeptEntry,
   isKeepExpired,
+  buildDependentInfo,
+  parseOverridePackageName,
 } from "../../../../src/core/appendix/utils";
 
 test("mergeOverrideReasons - should return reason when provided", () => {
@@ -688,4 +690,52 @@ test("toCompactAppendix - preserves full ledger for KeepConstraint entries", () 
 
   const result = toCompactAppendix(appendix);
   expect(result["lodash@4.17.21"]).toHaveProperty("ledger");
+});
+
+test("parseOverridePackageName - resolves pnpm selector and nested override keys to the real package name", () => {
+  expect(parseOverridePackageName("minimatch")).toBe("minimatch");
+  expect(parseOverridePackageName("minimatch@<4")).toBe("minimatch");
+  expect(parseOverridePackageName("minimatch@>=9 <10")).toBe("minimatch");
+  expect(parseOverridePackageName("path-to-regexp@>=6 <7")).toBe("path-to-regexp");
+  expect(parseOverridePackageName("uuid@<11.1.1")).toBe("uuid");
+  expect(parseOverridePackageName("@scope/pkg@>=1 <2")).toBe("@scope/pkg");
+  expect(parseOverridePackageName("@protobufjs/utf8")).toBe("@protobufjs/utf8");
+  expect(parseOverridePackageName("gray-matter>js-yaml")).toBe("js-yaml");
+  expect(parseOverridePackageName("foo@1>@scope/bar@<2")).toBe("@scope/bar");
+});
+
+test("buildDependentInfo - resolves selector-range key to real name for graph lookup", () => {
+  const info = buildDependentInfo(false, "minimatch@>=9 <10", undefined, undefined, {
+    minimatch: ["glob", "rimraf"],
+  });
+  expect(info).toContain("required by");
+  expect(info).not.toContain("unused override");
+});
+
+test("buildDependentInfo - resolves selector-range key to real name for tree lookup", () => {
+  const info = buildDependentInfo(
+    false,
+    "minimatch@<4",
+    undefined,
+    { minimatch: "3.1.5" },
+    undefined,
+  );
+  expect(info).toContain("transitive dependency");
+  expect(info).not.toContain("unused override");
+});
+
+test("buildDependentInfo - resolves nested parent>child key to the child name", () => {
+  const info = buildDependentInfo(
+    false,
+    "gray-matter>js-yaml",
+    undefined,
+    { "js-yaml": "3.14.2" },
+    undefined,
+  );
+  expect(info).not.toContain("unused override");
+});
+
+test("buildDependentInfo - still flags a genuinely unused selector override", () => {
+  const info = buildDependentInfo(false, "minimatch@<4", undefined, {}, {});
+  expect(info).toContain("unused override");
 });


### PR DESCRIPTION
## Fixes

- Fixes # — `--remove-unused` was stripping pnpm selector-syntax overrides (`pkg@<range>`, `pkg@>=x <y`, `parent>child`) as false positives because dependent detection indexed the dependency tree/graph with the raw override key instead of the resolved package name, removing load-bearing security pins.

## Proposed Changes

- Add `parseOverridePackageName` to resolve an override key to its real package name (handling `@`-ranges, scopes, and `parent>child` nesting) and use it at every dependency tree/graph lookup in `src/core/appendix/{utils,index}.ts`, so installed selector/nested pins are correctly detected as used.
- Add an `isResolvablePackageName` fail-safe that keeps any override whose key can't be confidently resolved to a real package name, biasing toward keeping a stale override over deleting a load-bearing one.
- Add regression tests for selector-range and nested override keys at the `updateAppendix` and `buildDependentInfo` levels.

---

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.