### PR TITLE
chore(root): updates brew release

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -30,6 +30,8 @@ jobs:
     environment: homebrew-publish
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     env:
       FORMULA_PATH: pastoralist.rb
       RELEASE_REF: "${{ inputs.version }}"
@@ -46,6 +48,8 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
+
+      - run: bun install --config=/dev/null --frozen-lockfile
 
       - name: Validate stable version
         run: |
@@ -64,6 +68,37 @@ jobs:
             sleep 30
           done
           exit 1
+
+      - name: Build and test Perry binary
+        id: perry
+        run: |
+          bun run test:e2e:binary
+
+          case "$(uname -m)" in
+            arm64) ARCH=arm64 ;;
+            x86_64) ARCH=x64 ;;
+            *) exit 1 ;;
+          esac
+
+          BINARY="pastoralist-darwin-${ARCH}"
+          cp artifacts/pastoralist "$BINARY"
+          echo "binary=$BINARY" >> "$GITHUB_OUTPUT"
+
+      - name: Attest Perry binary
+        id: perry-attest
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: ${{ steps.perry.outputs.binary }}
+
+      - name: Prepare Perry attestation
+        id: perry-attestation
+        env:
+          BINARY: ${{ steps.perry.outputs.binary }}
+          BUNDLE_PATH: ${{ steps.perry-attest.outputs.bundle-path }}
+        run: |
+          SIGSTORE_BUNDLE="${BINARY}.sigstore.json"
+          cp "$BUNDLE_PATH" "$SIGSTORE_BUNDLE"
+          echo "sigstore_bundle=$SIGSTORE_BUNDLE" >> "$GITHUB_OUTPUT"
 
       - name: Generate formula from published tarball
         run: bun scripts/brew.ts generate
@@ -85,8 +120,10 @@ jobs:
 
       - name: Attach formula to GitHub release
         env:
+          BINARY: ${{ steps.perry.outputs.binary }}
           GITHUB_TOKEN: "${{ github.token }}"
-        run: gh release upload "v${VERSION}" "$FORMULA_PATH" --clobber
+          SIGSTORE_BUNDLE: ${{ steps.perry-attestation.outputs.sigstore_bundle }}
+        run: gh release upload "v${VERSION}" "$FORMULA_PATH" "$BINARY" "$SIGSTORE_BUNDLE" --clobber
 
       - name: Update Homebrew tap
         env:

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -138,3 +138,8 @@ jobs:
           git -c user.name=github-actions -c user.email=41898282+github-actions[bot]@users.noreply.github.com commit -m "pastoralist $VERSION"
           git push --set-upstream origin "$TAP_BRANCH"
           gh pr create --base main --head "$TAP_BRANCH" --title "pastoralist $VERSION" --body "Automated formula update for pastoralist $VERSION."
+
+      - name: Publish GitHub release
+        env:
+          GITHUB_TOKEN: "${{ github.token }}"
+        run: gh release edit "v${VERSION}" --draft=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,8 @@ jobs:
           RELEASE_ARGS=()
           if [[ "$VERSION" =~ -(alpha|beta|rc) ]]; then
             RELEASE_ARGS+=(--prerelease)
+          else
+            RELEASE_ARGS+=(--draft)
           fi
 
           if gh release view "$VERSION" > /dev/null 2>&1; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,6 @@ jobs:
       id-token: write
       contents: write
       attestations: write
-    env:
-      BINARY: pastoralist-linux-x64
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -45,11 +43,6 @@ jobs:
 
       - run: bun run build-dist
 
-      - name: Build Perry binary
-        run: |
-          bun run test:e2e:binary
-          cp artifacts/pastoralist "$BINARY"
-
       - name: Resolve npm dist-tag
         id: dist-tag
         run: |
@@ -68,13 +61,11 @@ jobs:
           test -n "$TARBALL"
           echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
 
-      - name: Attest release artifacts
+      - name: Attest npm tarball
         id: attest
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
-          subject-path: |
-            ${{ steps.pack.outputs.tarball }}
-            ${{ env.BINARY }}
+          subject-path: ${{ steps.pack.outputs.tarball }}
 
       - name: Prepare release attestation
         id: release-attestation
@@ -112,7 +103,7 @@ jobs:
             exit 0
           fi
 
-          gh release create "$VERSION" "$BINARY" "$TARBALL" "$SIGSTORE_BUNDLE" \
+          gh release create "$VERSION" "$TARBALL" "$SIGSTORE_BUNDLE" \
             --title "$VERSION" \
             --generate-notes \
             "${RELEASE_ARGS[@]}"
@@ -122,6 +113,8 @@ jobs:
     if: ${{ !contains(github.ref_name, '-') }}
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/homebrew.yml
     with:
       version: ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -211,10 +211,12 @@ maintenance PRs. See the
 Pastoralist can write to `package.json`, so the package should be boring to
 verify.
 
+<!-- release behavior from .github/workflows/publish.yml and .github/workflows/homebrew.yml -->
+
 - Releases are published from GitHub Actions with npm provenance
 - Published tarballs are packed before release and attached to GitHub Releases
   with artifact attestations
-- Perry binaries are built and tested before release
+- Perry binaries are built, tested, and attested only for stable Homebrew releases
 - Stable releases open a reviewed Homebrew tap update
 - CI runs CodeQL, OpenSSF Scorecard, unit, integration, e2e, and dependency
   policy checks


### PR DESCRIPTION
## Proposed Changes

- Limit Perry binary builds and publication to stable Homebrew releases.
- Keep npm and prerelease publication tarball-only.
- Publish stable GitHub releases only after Homebrew assets and the tap update are ready.

## Compatibility

The former `pastoralist-linux-x64` release asset and prerelease binaries are intentionally discontinued. Linux and prerelease users continue to install the npm package.