### PR TITLE
Improve pnpm support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        package-manager: [pnpm, npm, yarn]
+        package-manager: [pnpm, npm, yarn, pnpm-yaml, external-config]
       fail-fast: false
 
     name: e2e (${{ matrix.package-manager }})

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Socket Badge][socket-badge]][socket-package] [![npm version][npm-version-badge]][npm-package]
 [![npm downloads](https://img.shields.io/npm/dm/pastoralist.svg)](https://www.npmjs.com/package/pastoralist)
-[![TypeScript](https://img.shields.io/badge/TypeScript-types%20included-blue)](https://www.typescriptlang.org/)
 ![CI](https://github.com/yowainwright/pastoralist/actions/workflows/ci.yml/badge.svg)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/yowainwright/pastoralist/badge)](https://scorecard.dev/viewer/?uri=github.com/yowainwright/pastoralist)
 [![codecov](https://codecov.io/gh/yowainwright/pastoralist/branch/main/graph/badge.svg)](https://codecov.io/gh/yowainwright/pastoralist)

--- a/src/cli/action.ts
+++ b/src/cli/action.ts
@@ -1,4 +1,4 @@
-import { loadCliConfig, loadConfig } from "../config";
+import { loadCliConfig, loadConfig, loadConfigWithSource } from "../config";
 import { IS_DEBUGGING } from "../constants";
 import { resolveJSON } from "../core/package";
 import { update } from "../core/update";
@@ -271,6 +271,7 @@ const defaultActionDeps: ActionDeps = {
   createTerminalGraph,
   getLedgerAddedDate,
   loadConfig,
+  loadConfigWithSource,
   processExit: (code: number) => process.exit(code),
 };
 

--- a/src/cli/security/index.ts
+++ b/src/cli/security/index.ts
@@ -344,7 +344,7 @@ export const handleSecurityResults = (
 
   const shouldApplyAutoFix = overridesToApply.length > 0 && !mergedOptions.dryRun;
   if (shouldApplyAutoFix) {
-    securityChecker.applyAutoFix(overridesToApply, mergedOptions.path);
+    securityChecker.applyAutoFix(overridesToApply, mergedOptions.path, mergedOptions.config);
   }
 
   spinner.stop();

--- a/src/cli/security/index.ts
+++ b/src/cli/security/index.ts
@@ -211,6 +211,7 @@ const buildSecurityCheckOptions = (
   Object.assign({}, mergedOptions, {
     depPaths: scanPaths,
     root: mergedOptions.root || "./",
+    packageJsonPath: mergedOptions.path,
     onProgress: createProgressHandler(spinner),
     severityThreshold: config?.pastoralist?.security?.severityThreshold,
     excludePackages: config?.pastoralist?.security?.excludePackages,

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,8 +1,14 @@
-import type { AppendixItem, Options, PastoralistJSON, PastoralistResult } from "../types";
+import type {
+  AppendixItem,
+  AppendixTarget,
+  Options,
+  PastoralistJSON,
+  PastoralistResult,
+} from "../types";
 import type { update } from "../core/update";
 import type { createTerminalGraph } from "../dx";
 import type { resolveJSON } from "../core/package";
-import type { loadConfig } from "../config";
+import type { loadConfig, loadConfigWithSource } from "../config";
 import type { getLedgerAddedDate } from "../utils";
 import type { createSpinner, green, logger as createLogger, quickConfirm } from "../utils";
 import type { initCommand } from "./cmds/init";
@@ -35,8 +41,10 @@ export type UpdateResultData = Pick<
 export type UpdateContext = ReturnType<typeof update>;
 
 export type LoadedCliConfig = {
+  appendixTarget?: AppendixTarget;
   path: string;
   config: PastoralistJSON;
+  manifestConfig: PastoralistJSON;
   mergedOptions: Options;
 };
 
@@ -44,6 +52,7 @@ export type CliConfigDeps = {
   resolveJSON: typeof resolveJSON;
   buildMergedOptions: typeof buildMergedOptions;
   loadConfig?: typeof loadConfig;
+  loadConfigWithSource?: typeof loadConfigWithSource;
 };
 
 export type RuntimeDeps = {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -114,7 +114,11 @@ const hasUpdateChanges = (
 ): boolean => {
   const previousAppendix = config?.pastoralist?.appendix || {};
   const previousOverrides =
-    config?.overrides || config?.resolutions || config?.pnpm?.overrides || {};
+    updateResult.overrideSource?.overrides ||
+    config?.overrides ||
+    config?.resolutions ||
+    config?.pnpm?.overrides ||
+    {};
   const appendixChanged =
     JSON.stringify(updateResult.finalAppendix || {}) !== JSON.stringify(previousAppendix);
   const overridesChanged =

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -6,11 +6,20 @@ import type { Options, PastoralistJSON } from "../types";
 import { resolvePathFromRoot } from "../cli/utils";
 import type { CliConfigDeps, LoadedCliConfig } from "../cli/types";
 import { logger } from "../utils";
-import type { AppendixItem, ConfigAppendix, PastoralistConfig, SecurityConfig } from "./types";
+import type {
+  AppendixItem,
+  ConfigAppendix,
+  ConfigSource,
+  LoadedConfig,
+  MergedExternalConfig,
+  PastoralistConfig,
+  SecurityConfig,
+} from "./types";
 import { CONFIG_FILES, UNSUPPORTED_TYPESCRIPT_CONFIG } from "./constants";
 import { safeValidateConfig } from "./validators";
+import { loadTargetAppendix, resolveAppendixTarget } from "../core/appendix";
 
-const configCache = new Map<string, PastoralistConfig>();
+const configCache = new Map<string, LoadedConfig>();
 const log = logger({ file: "config/index.ts" });
 
 export const clearConfigCache = (): void => {
@@ -70,7 +79,7 @@ const tryLoadConfig = async (
   filename: string,
   root: string,
   validate: boolean,
-): Promise<PastoralistConfig | null> => {
+): Promise<LoadedConfig | null> => {
   const path = resolve(root, filename);
 
   if (!existsSync(path)) return null;
@@ -78,7 +87,10 @@ const tryLoadConfig = async (
   try {
     const rawConfig = await loadConfigFile(filename, path);
     if (!rawConfig) return null;
-    return validateAndReturn(rawConfig, validate);
+    const config = validateAndReturn(rawConfig, validate);
+    if (!config) return null;
+    const format = isJsonFile(filename) ? "json" : "javascript";
+    return { appendixTarget: undefined, config, source: { format, path } };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     log.fail(`Failed to load config from ${filename}: ${errorMessage}`);
@@ -100,12 +112,12 @@ const loadFirstAvailableConfig = async (
   filenames: readonly string[],
   root: string,
   validate: boolean,
-): Promise<PastoralistConfig | undefined> => {
+): Promise<LoadedConfig | undefined> => {
   const [filename, ...remaining] = filenames;
   if (!filename) return undefined;
 
-  const config = await tryLoadConfig(filename, root, validate);
-  if (config !== null) return config;
+  const loaded = await tryLoadConfig(filename, root, validate);
+  if (loaded !== null) return loaded;
 
   return loadFirstAvailableConfig(remaining, root, validate);
 };
@@ -114,11 +126,22 @@ export const loadExternalConfig = async (
   root: string = process.cwd(),
   validate: boolean = true,
 ): Promise<PastoralistConfig | undefined> => {
-  const config = await loadFirstAvailableConfig(CONFIG_FILES, root, validate);
-  if (config !== undefined) return config;
+  const loaded = await loadFirstAvailableConfig(CONFIG_FILES, root, validate);
+  if (loaded !== undefined) return loaded.config;
 
   warnIfUnsupportedTypeScriptConfigExists(root);
   return undefined;
+};
+
+const loadExternalConfigWithSource = async (
+  root: string,
+  validate: boolean,
+): Promise<LoadedConfig> => {
+  const loaded = await loadFirstAvailableConfig(CONFIG_FILES, root, validate);
+  if (loaded) return loaded;
+
+  warnIfUnsupportedTypeScriptConfigExists(root);
+  return { appendixTarget: undefined, config: undefined, source: undefined };
 };
 
 const mergeDependents = (external: AppendixItem, packageJson: AppendixItem) => {
@@ -190,26 +213,46 @@ export const mergeConfigs = (
   });
 };
 
+const mergeTargetAppendix = (
+  config: PastoralistConfig | undefined,
+  source: ConfigSource | undefined,
+  appendixTarget: LoadedConfig["appendixTarget"],
+): PastoralistConfig | undefined => {
+  const targetIsLoadedConfig = appendixTarget?.path === source?.path;
+  if (targetIsLoadedConfig) return config;
+
+  const appendix = loadTargetAppendix(appendixTarget);
+  if (!appendix) return config;
+  return mergeConfigs({ appendix }, config);
+};
+
+export const loadConfigWithSource = async (
+  root: string = process.cwd(),
+  packageJsonConfig?: PastoralistConfig,
+  validate: boolean = true,
+): Promise<LoadedConfig> => {
+  const cacheKey = `${root}:${validate}:${JSON.stringify(packageJsonConfig)}`;
+  const cached = configCache.get(cacheKey);
+
+  if (cached) return cached;
+
+  const external = await loadExternalConfigWithSource(root, validate);
+  const merged = mergeConfigs(external.config, packageJsonConfig);
+  const appendixTarget = resolveAppendixTarget(merged, external.source, root);
+  const config = mergeTargetAppendix(merged, external.source, appendixTarget);
+  const loaded = { appendixTarget, config, source: external.source };
+
+  if (config) configCache.set(cacheKey, loaded);
+  return loaded;
+};
+
 export const loadConfig = async (
   root: string = process.cwd(),
   packageJsonConfig?: PastoralistConfig,
   validate: boolean = true,
 ): Promise<PastoralistConfig | undefined> => {
-  const cacheKey = `${root}:${validate}:${JSON.stringify(packageJsonConfig)}`;
-  const cached = configCache.get(cacheKey);
-
-  if (cached) {
-    return cached;
-  }
-
-  const externalConfig = await loadExternalConfig(root, validate);
-  const merged = mergeConfigs(externalConfig, packageJsonConfig);
-
-  if (merged) {
-    configCache.set(cacheKey, merged);
-  }
-
-  return merged;
+  const loaded = await loadConfigWithSource(root, packageJsonConfig, validate);
+  return loaded.config;
 };
 
 const loadPackageConfig = (
@@ -226,17 +269,32 @@ const createPastoralistField = (config: PastoralistConfig | undefined) => {
   return { pastoralist: config };
 };
 
+const loadMergedConfig = async (
+  root: string,
+  packageConfig: PastoralistJSON,
+  deps: Pick<CliConfigDeps, "loadConfig" | "loadConfigWithSource">,
+): Promise<LoadedConfig> => {
+  if (deps.loadConfigWithSource) {
+    return deps.loadConfigWithSource(root, packageConfig.pastoralist);
+  }
+
+  const configLoader = deps.loadConfig || loadConfig;
+  const config = await configLoader(root, packageConfig.pastoralist);
+  return { appendixTarget: undefined, config, source: undefined };
+};
+
 const mergeExternalConfig = async (
   path: string,
   options: Options,
   packageConfig: PastoralistJSON,
-  deps: Pick<CliConfigDeps, "loadConfig">,
-): Promise<PastoralistJSON> => {
+  deps: Pick<CliConfigDeps, "loadConfig" | "loadConfigWithSource">,
+): Promise<MergedExternalConfig> => {
   const configRoot = options.root || dirname(resolve(path));
-  const configLoader = deps.loadConfig || loadConfig;
-  const mergedConfig = await configLoader(configRoot, packageConfig.pastoralist);
-  const pastoralist = createPastoralistField(mergedConfig);
-  return Object.assign({}, packageConfig, pastoralist);
+  const loaded = await loadMergedConfig(configRoot, packageConfig, deps);
+  const pastoralist = createPastoralistField(loaded.config);
+  const config = Object.assign({}, packageConfig, pastoralist);
+  const appendixTarget = loaded.appendixTarget;
+  return { appendixTarget, config };
 };
 
 const resolveSecurityEnabled = (
@@ -274,7 +332,9 @@ const mergeOptionsWithConfig = (
   options: Options,
   rest: Omit<Options, "isTestingCLI" | "init">,
   config: PastoralistJSON,
+  manifestConfig: PastoralistJSON,
   path: string,
+  appendixTarget: LoadedConfig["appendixTarget"],
   deps: Pick<CliConfigDeps, "buildMergedOptions">,
 ): Options => {
   const securityConfig = buildSecurityConfig(config);
@@ -285,7 +345,9 @@ const mergeOptionsWithConfig = (
     securityConfig.provider,
   );
   const root = createRootField(options.root);
-  return Object.assign({}, mergedOptions, { config, path }, root);
+  const configFields = { config, manifestConfig, path };
+  const targetField = appendixTarget ? { appendixTarget } : undefined;
+  return Object.assign({}, mergedOptions, configFields, root, targetField);
 };
 
 export const loadCliConfig = async (
@@ -296,9 +358,17 @@ export const loadCliConfig = async (
   const relativePath = options.path || "package.json";
   const path = resolvePathFromRoot(relativePath, options.root);
   const packageConfig = loadPackageConfig(path, deps);
-  const config = await mergeExternalConfig(path, options, packageConfig, deps);
-  const mergedOptions = mergeOptionsWithConfig(options, rest, config, path, deps);
-  return { path, config, mergedOptions };
+  const loaded = await mergeExternalConfig(path, options, packageConfig, deps);
+  const mergedOptions = mergeOptionsWithConfig(
+    options,
+    rest,
+    loaded.config,
+    packageConfig,
+    path,
+    loaded.appendixTarget,
+    deps,
+  );
+  return Object.assign({}, loaded, { manifestConfig: packageConfig, path, mergedOptions });
 };
 
 export * from "./constants";

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -5,7 +5,7 @@ import type {
   SECURITY_PROVIDERS,
   SEVERITY_THRESHOLDS,
 } from "./constants";
-import type { KeepConstraint } from "../types";
+import type { AppendixTarget, KeepConstraint, PastoralistJSON } from "../types";
 
 export type SecurityProvider = (typeof SECURITY_PROVIDERS)[number];
 export type SecurityProviders = SecurityProvider | SecurityProvider[];
@@ -58,12 +58,30 @@ export type SecurityConfig = {
 
 export type PastoralistConfig = {
   appendix?: Appendix;
+  appendixSource?: string;
   compactAppendix?: boolean;
   depPaths?: DepPathAlias | string[];
+  overrideSource?: string;
   checkSecurity?: boolean;
   overridePaths?: Record<string, Appendix>;
   resolutionPaths?: Record<string, Appendix>;
   security?: SecurityConfig;
+};
+
+export type ConfigSource = {
+  format: "json" | "javascript";
+  path: string;
+};
+
+export type LoadedConfig = {
+  appendixTarget: AppendixTarget | undefined;
+  config: PastoralistConfig | undefined;
+  source: ConfigSource | undefined;
+};
+
+export type MergedExternalConfig = {
+  appendixTarget: AppendixTarget | undefined;
+  config: PastoralistJSON;
 };
 
 export type ConfigAppendix = PastoralistConfig["appendix"];

--- a/src/config/validators.ts
+++ b/src/config/validators.ts
@@ -171,7 +171,9 @@ const PASTORALIST_CONFIG_FIELDS: FieldValidation[] = createFieldValidations(
   validateAppendixCollection,
 ).concat([
   { field: "appendix", validator: validateAppendix },
+  { field: "appendixSource", validator: isString },
   { field: "depPaths", validator: validateDepPaths },
+  { field: "overrideSource", validator: isString },
   { field: "checkSecurity", validator: isBoolean },
   { field: "security", validator: validateSecurityConfig },
 ]);

--- a/src/core/appendix/index.ts
+++ b/src/core/appendix/index.ts
@@ -1,7 +1,16 @@
-import { writeFileSync } from "fs";
-import { resolve } from "path";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { basename, dirname, resolve } from "path";
 import type {
   Appendix,
+  AppendixTarget,
   AppendixItem,
   OverridesType,
   OverrideValue,
@@ -9,6 +18,8 @@ import type {
   ResolveOverrides,
   AppendixDependencyContext,
 } from "../../types";
+import type { ConfigSource, PastoralistConfig } from "../../config/types";
+import { validateConfig } from "../../config/validators";
 import type { Logger } from "../../utils";
 import type {
   AppendixUpdateOptions,
@@ -38,6 +49,81 @@ import {
   parseOverridePackageName,
   isResolvablePackageName,
 } from "./utils";
+
+const isJsonConfigPath = (path: string): boolean => {
+  const filename = basename(path);
+  const isExtensionlessRc = filename === ".pastoralistrc";
+  const hasJsonExtension = filename.endsWith(".json");
+  return isExtensionlessRc || hasJsonExtension;
+};
+
+const resolveExplicitTarget = (path: string, root: string): AppendixTarget => {
+  const resolvedPath = resolve(root, path);
+  if (isJsonConfigPath(resolvedPath)) return { path: resolvedPath };
+  throw new Error(`Appendix source must be a JSON config file: ${resolvedPath}`);
+};
+
+export const resolveAppendixTarget = (
+  config: PastoralistConfig | undefined,
+  source: ConfigSource | undefined,
+  root: string,
+): AppendixTarget | undefined => {
+  if (config?.appendixSource) return resolveExplicitTarget(config.appendixSource, root);
+  if (source?.format === "json") return { path: source.path };
+  return undefined;
+};
+
+const readTargetConfig = (path: string): PastoralistConfig => {
+  if (!existsSync(path)) return {};
+  const content = readFileSync(path, "utf8");
+  return validateConfig(JSON.parse(content));
+};
+
+export const loadTargetAppendix = (target: AppendixTarget | undefined): Appendix | undefined => {
+  if (!target) return undefined;
+  return readTargetConfig(target.path).appendix;
+};
+
+const withoutAppendix = (config: PastoralistConfig): PastoralistConfig => {
+  const { appendix: _appendix, ...rest } = config;
+  return rest;
+};
+
+const updateTargetConfig = (config: PastoralistConfig, appendix: Appendix): PastoralistConfig => {
+  if (Object.keys(appendix).length === 0) return withoutAppendix(config);
+  return Object.assign({}, config, { appendix });
+};
+
+const getWriteMode = (path: string): number | undefined => {
+  if (!existsSync(path)) return undefined;
+  return statSync(path).mode;
+};
+
+const writeAtomic = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  const temporaryPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  const mode = getWriteMode(path);
+
+  try {
+    writeFileSync(temporaryPath, content, { flag: "wx", mode });
+    renameSync(temporaryPath, path);
+  } catch (error) {
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+    throw error;
+  }
+};
+
+export const writeTargetAppendix = (
+  target: AppendixTarget,
+  appendix: Appendix,
+  dryRun: boolean,
+): void => {
+  if (dryRun) return;
+  const currentConfig = readTargetConfig(target.path);
+  const updatedConfig = updateTargetConfig(currentConfig, appendix);
+  const content = JSON.stringify(updatedConfig, null, 2) + "\n";
+  writeAtomic(target.path, content);
+};
 
 const hasDependency = (deps: Record<string, string>, packageName: string): boolean =>
   Object.prototype.hasOwnProperty.call(deps, packageName);

--- a/src/core/overrides/constants.ts
+++ b/src/core/overrides/constants.ts
@@ -1,0 +1,3 @@
+import type { PackageManager } from "./types";
+
+export const PACKAGE_MANAGERS = new Set<PackageManager>(["npm", "yarn", "pnpm", "bun"]);

--- a/src/core/overrides/index.ts
+++ b/src/core/overrides/index.ts
@@ -1,13 +1,13 @@
-import { IS_DEBUGGING } from "../constants";
+import { IS_DEBUGGING } from "../../constants";
 import type {
   OverridesConfig,
   ResolveOverrides,
   OverridesType,
   OverrideValue,
   ResolveResolutionOptions,
-} from "../types";
-import { logger } from "../utils";
-import type { OverrideType } from "./types";
+} from "../../types";
+import { logger } from "../../utils";
+import type { OverrideSource, OverrideType } from "./types";
 
 const log = logger({ file: "overrides.ts", isLogging: IS_DEBUGGING });
 
@@ -89,6 +89,13 @@ const buildResultByType = (type: string, overrides: OverridesType): ResolveOverr
   if (type === "pnpmOverrides") return buildPnpmResult(overrides);
   if (type === "resolutions") return buildResolutionsResult(overrides);
   return buildNpmResult(overrides);
+};
+
+export const resolveOverridesFromSource = (source: OverrideSource): ResolveOverrides => {
+  if (Object.keys(source.overrides).length === 0) return undefined;
+  if (source.field === "resolutions") return buildResolutionsResult(source.overrides);
+  if (source.packageManager === "pnpm") return buildPnpmResult(source.overrides);
+  return buildNpmResult(source.overrides);
 };
 
 export const resolveOverrides = ({ config = {} }: ResolveResolutionOptions): ResolveOverrides => {
@@ -177,3 +184,7 @@ export const updateOverrides = (
 
   return filterRemovedOverrides(overrides, removableItems);
 };
+
+export { applyOverridesToSourceConfig, resolveOverrideSource, writeOverrideSource } from "./utils";
+export { parsePnpmWorkspaceOverrides, updatePnpmWorkspaceOverrides } from "./yaml";
+export type { OverrideSource, OverrideSourceKind } from "./types";

--- a/src/core/overrides/types.ts
+++ b/src/core/overrides/types.ts
@@ -1,0 +1,31 @@
+import type { OverridesType, PastoralistJSON, OverrideValue } from "../../types";
+import type {
+  OverrideField as PackageOverrideField,
+  PackageManager as DetectedPackageManager,
+} from "../package/types";
+
+export type PackageManager = DetectedPackageManager;
+export type OverrideField = PackageOverrideField;
+export type OverrideSourceKind = "manifest" | "json" | "yaml";
+
+export type OverrideType = {
+  type: string;
+  overrides: Record<string, OverrideValue>;
+};
+
+export type OverrideSource = {
+  kind: OverrideSourceKind;
+  path: string;
+  field: OverrideField | "overrides";
+  packageManager: PackageManager;
+  overrides: OverridesType;
+};
+
+export type OverrideSourceOptions = {
+  config: PastoralistJSON;
+  manifestPath: string;
+};
+
+export type WriteOverrideSourceOptions = {
+  dryRun?: boolean;
+};

--- a/src/core/overrides/utils.ts
+++ b/src/core/overrides/utils.ts
@@ -54,9 +54,15 @@ const resolveConfiguredSource = (
   return resolve(dirname(resolve(manifestPath)), configuredPath);
 };
 
+const hasWorkspaceOverrides = (path: string): boolean => {
+  if (!existsSync(path)) return false;
+  const content = readFileSync(path, "utf8");
+  return Object.keys(parsePnpmWorkspaceOverrides(content)).length > 0;
+};
+
 const resolvePnpmSource = (config: PastoralistJSON, manifestPath: string): string | undefined => {
   const workspacePath = resolve(dirname(resolve(manifestPath)), PNPM_WORKSPACE_FILE);
-  const usesWorkspaceSource = existsSync(workspacePath) || isPnpmEleven(config);
+  const usesWorkspaceSource = isPnpmEleven(config) || hasWorkspaceOverrides(workspacePath);
   return usesWorkspaceSource ? workspacePath : undefined;
 };
 

--- a/src/core/overrides/utils.ts
+++ b/src/core/overrides/utils.ts
@@ -1,0 +1,173 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { dirname, extname, resolve } from "path";
+import { PNPM_WORKSPACE_FILE } from "../constants";
+import type { OverridesType, PastoralistJSON } from "../../types";
+import { PACKAGE_MANAGERS } from "./constants";
+import type {
+  OverrideField,
+  OverrideSource,
+  OverrideSourceOptions,
+  PackageManager,
+  WriteOverrideSourceOptions,
+} from "./types";
+import {
+  applyOverridesToConfig,
+  detectPackageManager,
+  getExistingOverrideField,
+  getOverrideFieldForPackageManager,
+} from "../package/utils";
+import { parsePnpmWorkspaceOverrides, updatePnpmWorkspaceOverrides } from "./yaml";
+
+const getDeclaredPackageManager = (config: PastoralistJSON): PackageManager | undefined => {
+  const name = config.packageManager?.split("@")[0] as PackageManager | undefined;
+  const isKnownManager = Boolean(name && PACKAGE_MANAGERS.has(name));
+  if (!isKnownManager) return undefined;
+  return name;
+};
+
+const getPackageManager = (config: PastoralistJSON, manifestPath: string): PackageManager => {
+  const declaredManager = getDeclaredPackageManager(config);
+  if (declaredManager) return declaredManager;
+  const manifestRoot = dirname(resolve(manifestPath));
+  return detectPackageManager(manifestRoot);
+};
+
+const isPnpmEleven = (config: PastoralistJSON): boolean => {
+  const match = config.packageManager?.match(/^pnpm@(\d+)/);
+  if (!match) return false;
+  const major = Number(match[1]);
+  return major >= 11;
+};
+
+const isYamlFile = (path: string): boolean => {
+  const extension = extname(path).toLowerCase();
+  const isYamlExtension = extension === ".yaml" || extension === ".yml";
+  return isYamlExtension;
+};
+
+const resolveConfiguredSource = (
+  config: PastoralistJSON,
+  manifestPath: string,
+): string | undefined => {
+  const configuredPath = config.pastoralist?.overrideSource;
+  if (!configuredPath) return undefined;
+  return resolve(dirname(resolve(manifestPath)), configuredPath);
+};
+
+const resolvePnpmSource = (config: PastoralistJSON, manifestPath: string): string | undefined => {
+  const workspacePath = resolve(dirname(resolve(manifestPath)), PNPM_WORKSPACE_FILE);
+  const usesWorkspaceSource = existsSync(workspacePath) || isPnpmEleven(config);
+  return usesWorkspaceSource ? workspacePath : undefined;
+};
+
+const readJsonSource = (path: string): PastoralistJSON => {
+  if (!existsSync(path)) return {} as PastoralistJSON;
+  return JSON.parse(readFileSync(path, "utf8")) as PastoralistJSON;
+};
+
+const getOverridesFromField = (config: PastoralistJSON, field: OverrideField): OverridesType => {
+  if (field === "resolutions") return config.resolutions || {};
+  if (field === "pnpm") return config.pnpm?.overrides || {};
+  return config.overrides || {};
+};
+
+const resolveJsonField = (
+  sourceConfig: PastoralistJSON,
+  packageManager: PackageManager,
+): OverrideField => {
+  return (
+    getExistingOverrideField(sourceConfig) || getOverrideFieldForPackageManager(packageManager)
+  );
+};
+
+const createYamlSource = (path: string, packageManager: PackageManager): OverrideSource => {
+  const content = existsSync(path) ? readFileSync(path, "utf8") : "";
+  const overrides = parsePnpmWorkspaceOverrides(content);
+  return { kind: "yaml", path, field: "overrides", packageManager, overrides };
+};
+
+const createJsonSource = (
+  path: string,
+  manifestPath: string,
+  packageManager: PackageManager,
+  manifestConfig: PastoralistJSON,
+): OverrideSource => {
+  const isManifest = resolve(path) === resolve(manifestPath);
+  const sourceConfig = isManifest ? manifestConfig : readJsonSource(path);
+  const field = resolveJsonField(sourceConfig, packageManager);
+  const kind = isManifest ? "manifest" : "json";
+  const overrides = getOverridesFromField(sourceConfig, field);
+  return { kind, path, field, packageManager, overrides };
+};
+
+export const resolveOverrideSource = ({
+  config,
+  manifestPath,
+}: OverrideSourceOptions): OverrideSource => {
+  const packageManager = getPackageManager(config, manifestPath);
+  const configuredSource = resolveConfiguredSource(config, manifestPath);
+  const pnpmSource =
+    packageManager === "pnpm" ? resolvePnpmSource(config, manifestPath) : undefined;
+  const sourcePath = configuredSource || pnpmSource || resolve(manifestPath);
+
+  if (isYamlFile(sourcePath)) return createYamlSource(sourcePath, packageManager);
+  return createJsonSource(sourcePath, manifestPath, packageManager, config);
+};
+
+const removeOverrideField = (config: PastoralistJSON, field: OverrideField): PastoralistJSON => {
+  if (field === "resolutions") {
+    const { resolutions: _, ...rest } = config;
+    return rest as PastoralistJSON;
+  }
+  if (field === "overrides") {
+    const { overrides: _, ...rest } = config;
+    return rest as PastoralistJSON;
+  }
+
+  const { overrides: _, ...pnpm } = config.pnpm || {};
+  const { pnpm: _pnpm, ...rest } = config;
+  if (Object.keys(pnpm).length === 0) return rest as PastoralistJSON;
+  return Object.assign({}, rest, { pnpm });
+};
+
+export const applyOverridesToSourceConfig = (
+  config: PastoralistJSON,
+  source: OverrideSource,
+  overrides: OverridesType,
+): PastoralistJSON => {
+  const isJsonSource = source.kind === "manifest" || source.kind === "json";
+  if (!isJsonSource) return config;
+  const field = source.field as OverrideField;
+  if (Object.keys(overrides).length === 0) return removeOverrideField(config, field);
+  return applyOverridesToConfig(config, overrides, field);
+};
+
+const writeYamlSource = (source: OverrideSource, overrides: OverridesType): void => {
+  const content = existsSync(source.path) ? readFileSync(source.path, "utf8") : "";
+  const updated = updatePnpmWorkspaceOverrides(content, overrides);
+  if (updated === content) return;
+  writeFileSync(source.path, updated);
+};
+
+const writeJsonSource = (source: OverrideSource, overrides: OverridesType): void => {
+  const config = readJsonSource(source.path);
+  const updated = applyOverridesToSourceConfig(config, source, overrides);
+  const content = `${JSON.stringify(updated, null, 2)}\n`;
+  const current = existsSync(source.path) ? readFileSync(source.path, "utf8") : "";
+  if (content === current) return;
+  writeFileSync(source.path, content);
+};
+
+export const writeOverrideSource = (
+  source: OverrideSource,
+  overrides: OverridesType,
+  options: WriteOverrideSourceOptions = {},
+): void => {
+  const shouldSkipWrite = options.dryRun || source.kind === "manifest";
+  if (shouldSkipWrite) return;
+  if (source.kind === "yaml") {
+    writeYamlSource(source, overrides);
+    return;
+  }
+  writeJsonSource(source, overrides);
+};

--- a/src/core/overrides/yaml.ts
+++ b/src/core/overrides/yaml.ts
@@ -1,0 +1,299 @@
+import type { OverridesType, OverrideValue } from "../../types";
+
+type YamlPair = {
+  key: string;
+  keySource: string;
+  valueSource: string;
+  suffix: string;
+  indent: string;
+};
+
+type YamlSection = {
+  start: number;
+  end: number;
+  pair: YamlPair;
+};
+
+type YamlEntry = YamlPair & { line: number };
+
+type ScanState = {
+  escaped: boolean;
+  quote?: string;
+};
+
+const QUOTE_CHARACTERS = new Set(['"', "'"]);
+const UNSAFE_SCALAR_CHARACTERS = new Set(":#{}[],&*!|>'\"%@`");
+
+const getIndent = (line: string): string => line.match(/^\s*/)?.[0] || "";
+
+const updateQuote = (quote: string | undefined, character: string): string | undefined => {
+  if (character === quote) return undefined;
+  if (quote) return quote;
+  if (QUOTE_CHARACTERS.has(character)) return character;
+  return undefined;
+};
+
+const scanCharacter = (state: ScanState, character: string): ScanState => {
+  if (state.escaped) return { quote: state.quote, escaped: false };
+  const startsEscape = state.quote === '"' && character === "\\";
+  if (startsEscape) return { quote: state.quote, escaped: true };
+  return { quote: updateQuote(state.quote, character), escaped: false };
+};
+
+const findSeparator = (line: string): number => {
+  let state: ScanState = { escaped: false };
+  return line.split("").findIndex((character, index) => {
+    const isUnquoted = !state.quote;
+    const isUnescaped = !state.escaped;
+    const canMatchSeparator = isUnquoted && isUnescaped;
+    const isSeparator = canMatchSeparator && character === ":";
+    const hasBoundary = /\s|$/.test(line[index + 1] || "");
+    const isYamlSeparator = isSeparator && hasBoundary;
+    state = scanCharacter(state, character);
+    return isYamlSeparator;
+  });
+};
+
+const parseQuotedScalar = (value: string): string => {
+  if (value.startsWith('"')) return JSON.parse(value) as string;
+  if (value.startsWith("'")) return value.slice(1, -1).replaceAll("''", "'");
+  return value;
+};
+
+const findComment = (value: string): number => {
+  let state: ScanState = { escaped: false };
+  return value.split("").findIndex((character, index) => {
+    const isUnquoted = !state.quote;
+    const isUnescaped = !state.escaped;
+    const canMatchComment = isUnquoted && isUnescaped;
+    const isComment = canMatchComment && character === "#";
+    const hasBoundary = /\s/.test(value[index - 1] || " ");
+    const startsComment = isComment && hasBoundary;
+    state = scanCharacter(state, character);
+    return startsComment;
+  });
+};
+
+const splitValue = (source: string): Pick<YamlPair, "valueSource" | "suffix"> => {
+  const trimmed = source.trimStart();
+  const commentIndex = findComment(trimmed);
+  if (commentIndex < 0) return { valueSource: trimmed.trimEnd(), suffix: "" };
+
+  const valueSource = trimmed.slice(0, commentIndex).trimEnd();
+  const suffix = ` ${trimmed.slice(commentIndex).trimEnd()}`;
+  return { valueSource, suffix };
+};
+
+const parsePair = (line: string): YamlPair | undefined => {
+  const indent = getIndent(line);
+  const content = line.slice(indent.length);
+  const isIgnoredContent = !content || content.startsWith("#") || content.startsWith("-");
+  if (isIgnoredContent) return undefined;
+
+  const separator = findSeparator(content);
+  if (separator < 0) return undefined;
+  const keySource = content.slice(0, separator).trim();
+  const key = parseQuotedScalar(keySource);
+  const value = splitValue(content.slice(separator + 1));
+  return Object.assign({}, { key, keySource, indent }, value);
+};
+
+const isTopLevelBoundary = (line: string): boolean => {
+  const isIgnoredLine = !line || /^(?:\s|#)/.test(line);
+  if (isIgnoredLine) return false;
+  const hasPair = Boolean(parsePair(line));
+  const isDocumentBoundary = line === "---" || line === "...";
+  return hasPair || isDocumentBoundary;
+};
+
+const findOverridesSection = (lines: string[]): YamlSection | undefined => {
+  const start = lines.findIndex((line) => {
+    const pair = parsePair(line);
+    const isOverridesSection = pair?.indent === "" && pair.key === "overrides";
+    return isOverridesSection;
+  });
+  if (start < 0) return undefined;
+
+  const relativeEnd = lines.slice(start + 1).findIndex(isTopLevelBoundary);
+  const hasNoBoundary = relativeEnd < 0;
+  const absoluteEnd = start + relativeEnd + 1;
+  const end = hasNoBoundary ? lines.length : absoluteEnd;
+  const pair = parsePair(lines[start])!;
+  return { start, end, pair };
+};
+
+const findEntryIndent = (lines: string[], section: YamlSection): number | undefined => {
+  const indents = lines
+    .slice(section.start + 1, section.end)
+    .map(parsePair)
+    .filter((pair): pair is YamlPair => Boolean(pair))
+    .map((pair) => pair.indent.length)
+    .filter((indent) => indent > 0);
+  if (indents.length === 0) return undefined;
+  return Math.min(...indents);
+};
+
+const findEntries = (lines: string[], section: YamlSection): YamlEntry[] => {
+  const entryIndent = findEntryIndent(lines, section);
+  if (entryIndent === undefined) return [];
+
+  const createEntry = (line: string, offset: number): YamlEntry[] => {
+    const pair = parsePair(line);
+    const isEntry = Boolean(pair && pair.indent.length === entryIndent);
+    if (!isEntry) return [];
+    const entryLine = section.start + offset + 1;
+    return [Object.assign({}, pair, { line: entryLine })];
+  };
+
+  return lines.slice(section.start + 1, section.end).flatMap(createEntry);
+};
+
+const parseFlowMapping = (source: string): OverridesType => {
+  const isEmptyMapping = !source || source === "{}";
+  if (isEmptyMapping) return {};
+  const parsed = JSON.parse(source) as unknown;
+  const isNonNullObject = typeof parsed === "object" && parsed !== null;
+  const isObject = isNonNullObject && !Array.isArray(parsed);
+  if (!isObject) throw new Error("pnpm overrides must be a YAML mapping");
+  return parsed as OverridesType;
+};
+
+const parseNestedFlowMapping = (source: string): Record<string, string> => {
+  const mapping = parseFlowMapping(source);
+  const hasOnlyStringValues = Object.values(mapping).every((value) => typeof value === "string");
+  if (!hasOnlyStringValues) throw new Error("nested pnpm overrides must contain string values");
+  return mapping as Record<string, string>;
+};
+
+const parseOverrideValue = (source: string): OverrideValue => {
+  const isFlowMapping = source.startsWith("{") && source.endsWith("}");
+  if (isFlowMapping) return parseNestedFlowMapping(source);
+  return parseQuotedScalar(source);
+};
+
+export const parsePnpmWorkspaceOverrides = (content: string): OverridesType => {
+  const lines = content.split(/\r?\n/);
+  const section = findOverridesSection(lines);
+  if (!section) return {};
+  if (section.pair.valueSource) return parseFlowMapping(section.pair.valueSource);
+
+  return Object.fromEntries(
+    findEntries(lines, section)
+      .filter((entry) => entry.valueSource)
+      .map((entry) => [entry.key, parseOverrideValue(entry.valueSource)]),
+  );
+};
+
+const formatNewScalar = (value: OverrideValue): string => JSON.stringify(value);
+
+const hasUnsafeScalarCharacter = (value: string): boolean => {
+  return Array.from(value).some((character) => UNSAFE_SCALAR_CHARACTERS.has(character));
+};
+
+const formatUpdatedScalar = (value: OverrideValue, previous: string): string => {
+  if (typeof value !== "string") return JSON.stringify(value);
+  if (previous.startsWith("'")) return `'${value.replaceAll("'", "''")}'`;
+  if (previous.startsWith('"')) return JSON.stringify(value);
+  const hasValue = value.length > 0;
+  const hasWhitespace = /\s/.test(value);
+  const isSafePlainValue = hasValue && !hasWhitespace && !hasUnsafeScalarCharacter(value);
+  return isSafePlainValue ? value : JSON.stringify(value);
+};
+
+const hasSameValue = (entry: YamlEntry, value: OverrideValue): boolean => {
+  try {
+    return JSON.stringify(parseOverrideValue(entry.valueSource)) === JSON.stringify(value);
+  } catch {
+    return false;
+  }
+};
+
+const updateEntry = (line: string, entry: YamlEntry, value: OverrideValue): string => {
+  if (hasSameValue(entry, value)) return line;
+  const scalar = formatUpdatedScalar(value, entry.valueSource);
+  return `${entry.indent}${entry.keySource}: ${scalar}${entry.suffix}`;
+};
+
+const updateExistingLine = (
+  line: string,
+  index: number,
+  entriesByLine: Map<number, YamlEntry>,
+  overrides: OverridesType,
+): string[] => {
+  const entry = entriesByLine.get(index);
+  if (!entry) return [line];
+  const value = overrides[entry.key];
+  if (value === undefined) return [];
+  return [updateEntry(line, entry, value)];
+};
+
+const updateExistingEntries = (
+  lines: string[],
+  section: YamlSection,
+  overrides: OverridesType,
+): string[] => {
+  const entriesByLine = new Map(findEntries(lines, section).map((entry) => [entry.line, entry]));
+  return lines.flatMap((line, index) => updateExistingLine(line, index, entriesByLine, overrides));
+};
+
+const appendNewEntries = (lines: string[], overrides: OverridesType): string[] => {
+  const section = findOverridesSection(lines)!;
+  const entries = findEntries(lines, section);
+  const existingKeys = new Set(entries.map((entry) => entry.key));
+  const newKeys = Object.keys(overrides).filter((key) => !existingKeys.has(key));
+  if (newKeys.length === 0) return lines;
+
+  const indent = entries[0]?.indent || "  ";
+  const newLines = newKeys.map((key) => {
+    const scalar = formatNewScalar(overrides[key]);
+    return `${indent}${JSON.stringify(key)}: ${scalar}`;
+  });
+  const insertionIndex = entries.at(-1)?.line ?? section.start;
+  const before = lines.slice(0, insertionIndex + 1);
+  const after = lines.slice(insertionIndex + 1);
+  return before.concat(newLines, after);
+};
+
+const replaceLine = (lines: string[], index: number, replacement: string): string[] => {
+  return lines.map((line, lineIndex) => (lineIndex === index ? replacement : line));
+};
+
+const replaceFlowSection = (lines: string[], section: YamlSection): string[] => {
+  if (!section.pair.valueSource) return lines;
+  return replaceLine(lines, section.start, `overrides:${section.pair.suffix}`);
+};
+
+const formatEmptySection = (lines: string[], overrides: OverridesType): string[] => {
+  if (Object.keys(overrides).length > 0) return lines;
+  const section = findOverridesSection(lines)!;
+  return replaceLine(lines, section.start, `overrides: {}${section.pair.suffix}`);
+};
+
+const ensureFinalNewline = (content: string, newline: string): string => {
+  const hasFinalNewline = content.length === 0 || content.endsWith(newline);
+  if (hasFinalNewline) return content;
+  return `${content}${newline}`;
+};
+
+const appendSection = (content: string, overrides: OverridesType, newline: string): string => {
+  if (Object.keys(overrides).length === 0) return content;
+  const prefix = ensureFinalNewline(content, newline);
+  const entries = Object.entries(overrides).map(
+    ([key, value]) => `  ${JSON.stringify(key)}: ${formatNewScalar(value)}`,
+  );
+  return `${prefix}overrides:${newline}${entries.join(newline)}${newline}`;
+};
+
+export const updatePnpmWorkspaceOverrides = (content: string, overrides: OverridesType): string => {
+  const newline = content.includes("\r\n") ? "\r\n" : "\n";
+  const lines = content.split(/\r?\n/);
+  const section = findOverridesSection(lines);
+  if (!section) return appendSection(content, overrides, newline);
+
+  const blockLines = replaceFlowSection(lines, section);
+  const blockSection = findOverridesSection(blockLines)!;
+  const updatedLines = updateExistingEntries(blockLines, blockSection, overrides);
+  const appendedLines = appendNewEntries(updatedLines, overrides);
+  const finalLines = formatEmptySection(appendedLines, overrides);
+  return finalLines.join(newline);
+};

--- a/src/core/overrides/yaml.ts
+++ b/src/core/overrides/yaml.ts
@@ -14,11 +14,17 @@ type YamlSection = {
   pair: YamlPair;
 };
 
-type YamlEntry = YamlPair & { line: number };
+type YamlEntry = YamlPair & { line: number; end: number };
 
 type ScanState = {
   escaped: boolean;
   quote?: string;
+};
+
+type FlowSplitState = {
+  entries: string[];
+  scan: ScanState & { depth: number };
+  start: number;
 };
 
 const QUOTE_CHARACTERS = new Set(['"', "'"]);
@@ -47,7 +53,8 @@ const findSeparator = (line: string): number => {
     const isUnescaped = !state.escaped;
     const canMatchSeparator = isUnquoted && isUnescaped;
     const isSeparator = canMatchSeparator && character === ":";
-    const hasBoundary = /\s|$/.test(line[index + 1] || "");
+    const nextCharacter = line[index + 1] || "";
+    const hasBoundary = !nextCharacter || /\s/.test(nextCharacter);
     const isYamlSeparator = isSeparator && hasBoundary;
     state = scanCharacter(state, character);
     return isYamlSeparator;
@@ -137,7 +144,7 @@ const findEntries = (lines: string[], section: YamlSection): YamlEntry[] => {
   const entryIndent = findEntryIndent(lines, section);
   if (entryIndent === undefined) return [];
 
-  const createEntry = (line: string, offset: number): YamlEntry[] => {
+  const createEntry = (line: string, offset: number): Array<YamlPair & { line: number }> => {
     const pair = parsePair(line);
     const isEntry = Boolean(pair && pair.indent.length === entryIndent);
     if (!isEntry) return [];
@@ -145,17 +152,96 @@ const findEntries = (lines: string[], section: YamlSection): YamlEntry[] => {
     return [Object.assign({}, pair, { line: entryLine })];
   };
 
-  return lines.slice(section.start + 1, section.end).flatMap(createEntry);
+  const entries = lines.slice(section.start + 1, section.end).flatMap(createEntry);
+  return entries.map((entry, index) => {
+    const end = entries[index + 1]?.line ?? section.end;
+    return Object.assign({}, entry, { end });
+  });
+};
+
+const isFlowMapping = (source: string): boolean => {
+  const trimmed = source.trim();
+  return trimmed.startsWith("{") && trimmed.endsWith("}");
+};
+
+const updateFlowDepth = (state: ScanState & { depth: number }, character: string): number => {
+  const isQuotedOrEscaped = Boolean(state.quote || state.escaped);
+  if (isQuotedOrEscaped) return state.depth;
+  if (character === "{") return state.depth + 1;
+  if (character === "}") return state.depth - 1;
+  return state.depth;
+};
+
+const scanFlowEntry = (
+  source: string,
+  current: FlowSplitState,
+  character: string,
+  index: number,
+): FlowSplitState => {
+  const isComma = character === ",";
+  const isUnquoted = !current.scan.quote;
+  const isTopLevel = current.scan.depth === 0;
+  const isSeparator = isComma && isUnquoted && isTopLevel;
+  const entry = source.slice(current.start, index).trim();
+  const entries = isSeparator ? current.entries.concat(entry) : current.entries;
+  const start = isSeparator ? index + 1 : current.start;
+  const depth = updateFlowDepth(current.scan, character);
+  const scan = Object.assign({}, scanCharacter(current.scan, character), { depth });
+  return { entries, scan, start };
+};
+
+const splitFlowEntries = (source: string): string[] => {
+  const initial: FlowSplitState = { entries: [], scan: { escaped: false, depth: 0 }, start: 0 };
+  const result = source
+    .split("")
+    .reduce(
+      (current, character, index) => scanFlowEntry(source, current, character, index),
+      initial,
+    );
+  const finalEntry = source.slice(result.start).trim();
+  const entries = result.entries.concat(finalEntry).filter(Boolean);
+  return entries;
+};
+
+const findFlowSeparator = (source: string): number => {
+  let state: ScanState = { escaped: false };
+  return source.split("").findIndex((character, index) => {
+    const keySource = source.slice(0, index).trim();
+    const quote = keySource.at(0);
+    const hasQuote = Boolean(quote);
+    const isKnownQuote = Boolean(quote && QUOTE_CHARACTERS.has(quote));
+    const hasClosingQuote = Boolean(quote && keySource.endsWith(quote));
+    const hasQuotedKey = hasQuote && isKnownQuote && hasClosingQuote;
+    const nextCharacter = source[index + 1] || "";
+    const hasValueBoundary =
+      !nextCharacter || /\s/.test(nextCharacter) || "[{".includes(nextCharacter);
+    const isColon = character === ":";
+    const isUnquoted = !state.quote;
+    const isUnescaped = !state.escaped;
+    const canSeparate = isColon && isUnquoted && isUnescaped;
+    const hasKeyBoundary = hasQuotedKey || hasValueBoundary;
+    const isSeparator = canSeparate && hasKeyBoundary;
+    state = scanCharacter(state, character);
+    return isSeparator;
+  });
+};
+
+const parseFlowPair = (source: string): [string, OverrideValue] => {
+  const separator = findFlowSeparator(source);
+  if (separator < 0) throw new Error("pnpm overrides must be a YAML mapping");
+  const keySource = source.slice(0, separator).trim();
+  const valueSource = source.slice(separator + 1).trim();
+  const hasMissingPairValue = !keySource || !valueSource;
+  if (hasMissingPairValue) throw new Error("pnpm overrides must be a YAML mapping");
+  return [parseQuotedScalar(keySource), parseOverrideValue(valueSource)];
 };
 
 const parseFlowMapping = (source: string): OverridesType => {
-  const isEmptyMapping = !source || source === "{}";
-  if (isEmptyMapping) return {};
-  const parsed = JSON.parse(source) as unknown;
-  const isNonNullObject = typeof parsed === "object" && parsed !== null;
-  const isObject = isNonNullObject && !Array.isArray(parsed);
-  if (!isObject) throw new Error("pnpm overrides must be a YAML mapping");
-  return parsed as OverridesType;
+  const trimmed = source.trim();
+  if (!isFlowMapping(trimmed)) throw new Error("pnpm overrides must be a YAML mapping");
+  const content = trimmed.slice(1, -1).trim();
+  if (!content) return {};
+  return Object.fromEntries(splitFlowEntries(content).map(parseFlowPair));
 };
 
 const parseNestedFlowMapping = (source: string): Record<string, string> => {
@@ -166,9 +252,50 @@ const parseNestedFlowMapping = (source: string): Record<string, string> => {
 };
 
 const parseOverrideValue = (source: string): OverrideValue => {
-  const isFlowMapping = source.startsWith("{") && source.endsWith("}");
-  if (isFlowMapping) return parseNestedFlowMapping(source);
+  if (isFlowMapping(source)) return parseNestedFlowMapping(source);
   return parseQuotedScalar(source);
+};
+
+const findEntryContentEnd = (lines: string[], entry: YamlEntry): number => {
+  if (entry.valueSource) return entry.line + 1;
+  const relativeEnd = lines.slice(entry.line + 1, entry.end).findIndex((line) => {
+    const isContent = line.trim().length > 0;
+    const isComment = line.trimStart().startsWith("#");
+    const isNested = getIndent(line).length > entry.indent.length;
+    const isBoundary = isContent && !isComment && !isNested;
+    return isBoundary;
+  });
+  if (relativeEnd < 0) return entry.end;
+  const absoluteEnd = entry.line + relativeEnd + 1;
+  return absoluteEnd;
+};
+
+const findNestedEntries = (lines: string[], entry: YamlEntry): YamlPair[] => {
+  const contentEnd = findEntryContentEnd(lines, entry);
+  const pairs = lines
+    .slice(entry.line + 1, contentEnd)
+    .map(parsePair)
+    .filter((pair): pair is YamlPair => Boolean(pair));
+  const nestedIndent = Math.min(...pairs.map((pair) => pair.indent.length));
+  return pairs.filter((pair) => pair.indent.length === nestedIndent);
+};
+
+const parseNestedBlockMapping = (lines: string[], entry: YamlEntry): Record<string, string> => {
+  const pairs = findNestedEntries(lines, entry).map((pair): [string, string] => {
+    const value = parseOverrideValue(pair.valueSource);
+    if (typeof value !== "string") {
+      throw new Error("nested pnpm overrides must contain string values");
+    }
+    return [pair.key, value];
+  });
+  return Object.fromEntries(pairs);
+};
+
+const parseEntryValue = (lines: string[], entry: YamlEntry): OverrideValue | undefined => {
+  if (entry.valueSource) return parseOverrideValue(entry.valueSource);
+  const mapping = parseNestedBlockMapping(lines, entry);
+  if (Object.keys(mapping).length === 0) return undefined;
+  return mapping;
 };
 
 export const parsePnpmWorkspaceOverrides = (content: string): OverridesType => {
@@ -177,11 +304,12 @@ export const parsePnpmWorkspaceOverrides = (content: string): OverridesType => {
   if (!section) return {};
   if (section.pair.valueSource) return parseFlowMapping(section.pair.valueSource);
 
-  return Object.fromEntries(
-    findEntries(lines, section)
-      .filter((entry) => entry.valueSource)
-      .map((entry) => [entry.key, parseOverrideValue(entry.valueSource)]),
-  );
+  const entries = findEntries(lines, section).flatMap((entry): Array<[string, OverrideValue]> => {
+    const value = parseEntryValue(lines, entry);
+    if (value === undefined) return [];
+    return [[entry.key, value]];
+  });
+  return Object.fromEntries(entries);
 };
 
 const formatNewScalar = (value: OverrideValue): string => JSON.stringify(value);
@@ -200,31 +328,38 @@ const formatUpdatedScalar = (value: OverrideValue, previous: string): string => 
   return isSafePlainValue ? value : JSON.stringify(value);
 };
 
-const hasSameValue = (entry: YamlEntry, value: OverrideValue): boolean => {
+const hasSameValue = (lines: string[], entry: YamlEntry, value: OverrideValue): boolean => {
   try {
-    return JSON.stringify(parseOverrideValue(entry.valueSource)) === JSON.stringify(value);
+    return JSON.stringify(parseEntryValue(lines, entry)) === JSON.stringify(value);
   } catch {
     return false;
   }
 };
 
-const updateEntry = (line: string, entry: YamlEntry, value: OverrideValue): string => {
-  if (hasSameValue(entry, value)) return line;
+const updateEntry = (entry: YamlEntry, value: OverrideValue): string => {
   const scalar = formatUpdatedScalar(value, entry.valueSource);
   return `${entry.indent}${entry.keySource}: ${scalar}${entry.suffix}`;
 };
 
-const updateExistingLine = (
-  line: string,
-  index: number,
-  entriesByLine: Map<number, YamlEntry>,
+const updateExistingEntry = (
+  lines: string[],
+  entry: YamlEntry,
   overrides: OverridesType,
 ): string[] => {
-  const entry = entriesByLine.get(index);
-  if (!entry) return [line];
+  const contentEnd = findEntryContentEnd(lines, entry);
+  const nestedLines = lines.slice(entry.line + 1, contentEnd);
+  const preservedLines = nestedLines.filter((line) => {
+    const trimmed = line.trimStart();
+    const isEmpty = !trimmed;
+    const isComment = trimmed.startsWith("#");
+    const shouldPreserve = isEmpty || isComment;
+    return shouldPreserve;
+  });
+  const trailingLines = lines.slice(contentEnd, entry.end);
   const value = overrides[entry.key];
-  if (value === undefined) return [];
-  return [updateEntry(line, entry, value)];
+  if (value === undefined) return preservedLines.concat(trailingLines);
+  if (hasSameValue(lines, entry, value)) return lines.slice(entry.line, entry.end);
+  return [updateEntry(entry, value)].concat(preservedLines, trailingLines);
 };
 
 const updateExistingEntries = (
@@ -232,8 +367,12 @@ const updateExistingEntries = (
   section: YamlSection,
   overrides: OverridesType,
 ): string[] => {
-  const entriesByLine = new Map(findEntries(lines, section).map((entry) => [entry.line, entry]));
-  return lines.flatMap((line, index) => updateExistingLine(line, index, entriesByLine, overrides));
+  const entries = findEntries(lines, section);
+  if (entries.length === 0) return lines;
+  const beforeEntries = lines.slice(0, entries[0].line);
+  const updatedEntries = entries.flatMap((entry) => updateExistingEntry(lines, entry, overrides));
+  const afterEntries = lines.slice(section.end);
+  return beforeEntries.concat(updatedEntries, afterEntries);
 };
 
 const appendNewEntries = (lines: string[], overrides: OverridesType): string[] => {
@@ -248,7 +387,8 @@ const appendNewEntries = (lines: string[], overrides: OverridesType): string[] =
     const scalar = formatNewScalar(overrides[key]);
     return `${indent}${JSON.stringify(key)}: ${scalar}`;
   });
-  const insertionIndex = entries.at(-1)?.line ?? section.start;
+  const lastEntry = entries.at(-1);
+  const insertionIndex = lastEntry ? findEntryContentEnd(lines, lastEntry) - 1 : section.start;
   const before = lines.slice(0, insertionIndex + 1);
   const after = lines.slice(insertionIndex + 1);
   return before.concat(newLines, after);

--- a/src/core/package/index.ts
+++ b/src/core/package/index.ts
@@ -109,28 +109,44 @@ export const resolveJSON = (path: string): PastoralistJSON | undefined => {
 };
 
 const hasOtherPastoralistConfig = (config: PastoralistJSON): boolean => {
+  const hasAppendixSource = Boolean(config.pastoralist?.appendixSource);
   const hasOverridePaths = Boolean(config.pastoralist?.overridePaths);
   const hasResolutionPaths = Boolean(config.pastoralist?.resolutionPaths);
   const hasSecurity = Boolean(config.pastoralist?.security);
   const hasDepPaths = Boolean(config.pastoralist?.depPaths);
+  const hasOverrideSource = Boolean(config.pastoralist?.overrideSource);
 
+  if (hasAppendixSource) return true;
   if (hasOverridePaths) return true;
   if (hasResolutionPaths) return true;
   if (hasSecurity) return true;
+  if (hasOverrideSource) return true;
   return hasDepPaths;
 };
 
 const buildPreservedConfig = (config: PastoralistJSON) => {
+  const appendixSource = config.pastoralist?.appendixSource;
   const depPaths = config.pastoralist?.depPaths;
   const overridePaths = config.pastoralist?.overridePaths;
+  const overrideSource = config.pastoralist?.overrideSource;
   const resolutionPaths = config.pastoralist?.resolutionPaths;
   const security = config.pastoralist?.security;
+  const appendixSourceField = appendixSource ? { appendixSource } : undefined;
   const depPathsField = depPaths ? { depPaths } : undefined;
   const overridePathsField = overridePaths ? { overridePaths } : undefined;
+  const overrideSourceField = overrideSource ? { overrideSource } : undefined;
   const resolutionPathsField = resolutionPaths ? { resolutionPaths } : undefined;
   const securityField = security ? { security } : undefined;
 
-  return Object.assign({}, depPathsField, overridePathsField, resolutionPathsField, securityField);
+  return Object.assign(
+    {},
+    appendixSourceField,
+    depPathsField,
+    overridePathsField,
+    overrideSourceField,
+    resolutionPathsField,
+    securityField,
+  );
 };
 
 const removeAllOverrides = (config: PastoralistJSON): PastoralistJSON => {
@@ -271,7 +287,9 @@ const buildUpdatedPackageConfig = ({
   config,
   overrides,
   isTesting = false,
+  manageOverrides = true,
 }: UpdatePackageJSONOptions): PastoralistJSON => {
+  if (!manageOverrides) return applyAppendixToConfig(config, appendix);
   if (!hasPackageJsonData(appendix, overrides)) return processConfigWithoutOverrides(config);
   return processConfigWithOverrides(config, appendix, overrides || {}, isTesting, path);
 };
@@ -311,8 +329,16 @@ export const updatePackageJSON = ({
   isTesting = false,
   dryRun = false,
   silent = false,
+  manageOverrides = true,
 }: UpdatePackageJSONOptions): PastoralistJSON | void => {
-  const updatedConfig = buildUpdatedPackageConfig({ appendix, path, config, overrides, isTesting });
+  const updatedConfig = buildUpdatedPackageConfig({
+    appendix,
+    path,
+    config,
+    overrides,
+    isTesting,
+    manageOverrides,
+  });
   if (isTesting) return updatedConfig;
 
   const jsonString = formatJson(updatedConfig);

--- a/src/core/package/utils.ts
+++ b/src/core/package/utils.ts
@@ -16,7 +16,9 @@ export const detectPackageManager = (root: string = process.cwd()): PackageManag
   const isBun = lockFileExists("bun.lockb", root) || lockFileExists("bun.lock", root);
   if (isBun) return "bun";
   if (lockFileExists("yarn.lock", root)) return "yarn";
-  if (lockFileExists("pnpm-lock.yaml", root)) return "pnpm";
+  const isPnpm =
+    lockFileExists("pnpm-lock.yaml", root) || lockFileExists("pnpm-workspace.yaml", root);
+  if (isPnpm) return "pnpm";
   return "npm";
 };
 

--- a/src/core/security/index.ts
+++ b/src/core/security/index.ts
@@ -49,7 +49,7 @@ import {
 import { SecuritySetupWizard, promptForSetup } from "./setup";
 import type { SetupSecurityProvider } from "./types";
 import { KNOWN_PROVIDERS, PROVIDER_CONFIGS } from "./constants";
-import { readFileSync, copyFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { readFileSync, copyFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "fs";
 import { createHash } from "crypto";
 import { resolve, dirname, basename } from "path";
 import { updateAppendix } from "../appendix";
@@ -63,6 +63,22 @@ const resolveBackupCacheDir = (root: string, cacheDir?: string): string => {
   return resolve(baseCacheDir, BACKUP_CACHE_DIR);
 };
 
+type AutoFixFileBackup = {
+  originalPath: string;
+  backupPath?: string;
+};
+
+type AutoFixPlan = {
+  mergedOverrides: OverridesType;
+  overrideSource: OverrideSource;
+  updatedPackageJson: PastoralistJSON;
+};
+
+type AutoFixTransaction = {
+  backupPath: string;
+  files: AutoFixFileBackup[];
+};
+
 export class SecurityChecker {
   private providers: SecurityProvider[];
   private log: ReturnType<typeof logger>;
@@ -74,6 +90,7 @@ export class SecurityChecker {
   private readonly refreshCache: boolean;
   private readonly configuredCacheDir?: string;
   private readonly cacheRoot?: string;
+  private readonly autoFixBackups = new Map<string, AutoFixFileBackup[]>();
 
   constructor(options: SecurityProviderFactoryOptions) {
     this.log = logger({ file: "security/index.ts", isLogging: options.debug });
@@ -832,6 +849,46 @@ export class SecurityChecker {
     return backupPath;
   }
 
+  private createFileBackup(originalPath: string): AutoFixFileBackup {
+    if (!existsSync(originalPath)) return { originalPath };
+    const backupPath = this.createBackup(originalPath);
+    return { backupPath, originalPath };
+  }
+
+  private createAutoFixTransaction(
+    pkgPath: string,
+    overrideSource: OverrideSource,
+  ): AutoFixTransaction {
+    const sourcePaths = overrideSource.kind === "manifest" ? [] : [overrideSource.path];
+    const files = [pkgPath].concat(sourcePaths).map((path) => this.createFileBackup(path));
+    const backupPath = files[0].backupPath;
+    if (!backupPath) throw new Error(`Unable to back up package.json at ${pkgPath}`);
+    this.autoFixBackups.set(backupPath, files);
+    return { backupPath, files };
+  }
+
+  private restoreFileBackup(file: AutoFixFileBackup): void {
+    if (file.backupPath) {
+      copyFileSync(file.backupPath, file.originalPath);
+      return;
+    }
+    if (existsSync(file.originalPath)) unlinkSync(file.originalPath);
+  }
+
+  private restoreAutoFixFiles(files: AutoFixFileBackup[]): void {
+    files.forEach((file) => this.restoreFileBackup(file));
+  }
+
+  private restoreFailedAutoFix(transaction: AutoFixTransaction | undefined): void {
+    if (!transaction) return;
+    try {
+      this.restoreAutoFixFiles(transaction.files);
+    } catch (error) {
+      this.log.error("Failed to rollback partial auto-fix", "applyAutoFix", { error });
+    }
+    this.autoFixBackups.delete(transaction.backupPath);
+  }
+
   private applyOverridesToPackageJson(
     packageJson: PastoralistJSON,
     overrideSource: OverrideSource,
@@ -841,26 +898,41 @@ export class SecurityChecker {
     return applyOverridesToSourceConfig(packageJson, overrideSource, overrides);
   }
 
-  applyAutoFix(overrides: SecurityOverride[], packageJsonPath?: string): string | void {
+  private createAutoFixPlan(
+    overrides: SecurityOverride[],
+    pkgPath: string,
+    effectiveConfig?: PastoralistJSON,
+  ): AutoFixPlan {
+    const packageJson = this.readPackageJsonForAutoFix(pkgPath);
+    const sourceConfig = effectiveConfig || packageJson;
+    const newOverrides = this.generatePackageOverrides(overrides);
+    const overrideSource = resolveOverrideSource({ config: sourceConfig, manifestPath: pkgPath });
+    const mergedOverrides = Object.assign({}, overrideSource.overrides, newOverrides);
+    const updatedPackageJson = this.buildAutoFixedPackageJson(
+      packageJson,
+      overrideSource,
+      mergedOverrides,
+      newOverrides,
+      overrides,
+    );
+    return { mergedOverrides, overrideSource, updatedPackageJson };
+  }
+
+  applyAutoFix(
+    overrides: SecurityOverride[],
+    packageJsonPath?: string,
+    effectiveConfig?: PastoralistJSON,
+  ): string | void {
+    let transaction: AutoFixTransaction | undefined;
     try {
       const pkgPath = this.resolveAutoFixPackagePath(packageJsonPath);
-      const backupPath = this.createBackup(pkgPath);
-      const packageJson = this.readPackageJsonForAutoFix(pkgPath);
-      const newOverrides = this.generatePackageOverrides(overrides);
-      const overrideSource = resolveOverrideSource({ config: packageJson, manifestPath: pkgPath });
-      const mergedOverrides = Object.assign({}, overrideSource.overrides, newOverrides);
-      const updatedPackageJson = this.buildAutoFixedPackageJson(
-        packageJson,
-        overrideSource,
-        mergedOverrides,
-        newOverrides,
-        overrides,
-      );
-
-      this.writePackageJson(pkgPath, updatedPackageJson);
-      writeOverrideSource(overrideSource, mergedOverrides);
-      return backupPath;
+      const plan = this.createAutoFixPlan(overrides, pkgPath, effectiveConfig);
+      transaction = this.createAutoFixTransaction(pkgPath, plan.overrideSource);
+      this.writePackageJson(pkgPath, plan.updatedPackageJson);
+      writeOverrideSource(plan.overrideSource, plan.mergedOverrides);
+      return transaction.backupPath;
     } catch (error) {
+      this.restoreFailedAutoFix(transaction);
       this.log.error("Failed to apply auto-fix", "applyAutoFix", { error });
       const cause = error instanceof Error ? error : new Error(String(error));
       throw new Error(`Auto-fix failed: ${cause.message}`, { cause });
@@ -961,7 +1033,10 @@ export class SecurityChecker {
         throw new Error(`Backup file not found at ${backupPath}`);
       }
 
-      copyFileSync(backupPath, originalPath);
+      const trackedFiles = this.autoFixBackups.get(backupPath);
+      const files = trackedFiles || [{ backupPath, originalPath }];
+      this.restoreAutoFixFiles(files);
+      this.autoFixBackups.delete(backupPath);
 
       this.log.print(`Rolled back to ${backupPath}`);
     } catch (error) {

--- a/src/core/security/index.ts
+++ b/src/core/security/index.ts
@@ -20,7 +20,12 @@ import {
   WorkspaceVulnerabilityState,
 } from "../../types";
 import { Appendix, PastoralistJSON, OverridesType } from "../../types";
-import { detectPackageManager } from "../package";
+import {
+  applyOverridesToSourceConfig,
+  resolveOverrideSource,
+  writeOverrideSource,
+} from "../overrides";
+import type { OverrideSource } from "../overrides";
 import {
   logger,
   LRUCache,
@@ -291,7 +296,7 @@ export class SecurityChecker {
       generatedOverrides,
       options,
     );
-    const updates = await this.checkOverrideUpdates(config, alerts);
+    const updates = await this.checkOverrideUpdates(config, alerts, options.packageJsonPath);
 
     return {
       alerts: vulnerablePackages,
@@ -577,8 +582,9 @@ export class SecurityChecker {
   private async checkOverrideUpdates(
     config: PastoralistJSON,
     alerts: SecurityAlert[],
+    packageJsonPath?: string,
   ): Promise<OverrideUpdate[]> {
-    const existingOverrides = this.getExistingOverrides(config);
+    const existingOverrides = this.getExistingOverrides(config, packageJsonPath);
     const appendix = config.pastoralist?.appendix || {};
     const allEntries = Object.entries(existingOverrides);
 
@@ -599,7 +605,10 @@ export class SecurityChecker {
     return updates;
   }
 
-  private getExistingOverrides(config: PastoralistJSON): OverridesType {
+  private getExistingOverrides(config: PastoralistJSON, packageJsonPath?: string): OverridesType {
+    if (packageJsonPath) {
+      return resolveOverrideSource({ config, manifestPath: packageJsonPath }).overrides;
+    }
     const existingOverrides =
       config.overrides || config.pnpm?.overrides || config.resolutions || {};
     return existingOverrides;
@@ -823,7 +832,7 @@ export class SecurityChecker {
     return backupPath;
   }
 
-  private applyOverridesToPackageJson(
+  applyOverridesToPackageJson(
     packageJson: PastoralistJSON,
     packageManager: "npm" | "yarn" | "pnpm" | "bun",
     newOverrides: OverridesType,
@@ -845,14 +854,18 @@ export class SecurityChecker {
       const backupPath = this.createBackup(pkgPath);
       const packageJson = this.readPackageJsonForAutoFix(pkgPath);
       const newOverrides = this.generatePackageOverrides(overrides);
+      const overrideSource = resolveOverrideSource({ config: packageJson, manifestPath: pkgPath });
+      const mergedOverrides = Object.assign({}, overrideSource.overrides, newOverrides);
       const updatedPackageJson = this.buildAutoFixedPackageJson(
         packageJson,
-        pkgPath,
+        overrideSource,
+        mergedOverrides,
         newOverrides,
         overrides,
       );
 
       this.writePackageJson(pkgPath, updatedPackageJson);
+      writeOverrideSource(overrideSource, mergedOverrides);
       return backupPath;
     } catch (error) {
       this.log.error("Failed to apply auto-fix", "applyAutoFix", { error });
@@ -876,15 +889,15 @@ export class SecurityChecker {
 
   private buildAutoFixedPackageJson(
     packageJson: PastoralistJSON,
-    pkgPath: string,
+    overrideSource: OverrideSource,
+    mergedOverrides: OverridesType,
     newOverrides: OverridesType,
     overrides: SecurityOverride[],
   ): PastoralistJSON {
-    const packageManager = detectPackageManager(dirname(pkgPath));
-    const updatedPackageJson = this.applyOverridesToPackageJson(
+    const updatedPackageJson = applyOverridesToSourceConfig(
       packageJson,
-      packageManager,
-      newOverrides,
+      overrideSource,
+      mergedOverrides,
     );
 
     updatedPackageJson.pastoralist = updatedPackageJson.pastoralist || {};

--- a/src/core/security/index.ts
+++ b/src/core/security/index.ts
@@ -832,20 +832,13 @@ export class SecurityChecker {
     return backupPath;
   }
 
-  applyOverridesToPackageJson(
+  private applyOverridesToPackageJson(
     packageJson: PastoralistJSON,
-    packageManager: "npm" | "yarn" | "pnpm" | "bun",
-    newOverrides: OverridesType,
+    overrideSource: OverrideSource,
+    overrides: OverridesType,
   ): PastoralistJSON {
-    if (packageManager === "pnpm") {
-      const overrides = Object.assign({}, packageJson.pnpm?.overrides, newOverrides);
-      const pnpm = Object.assign({}, packageJson.pnpm, { overrides });
-      return Object.assign({}, packageJson, { pnpm });
-    }
-
-    const overrideField = this.getOverrideField(packageManager);
-    const overrides = Object.assign({}, packageJson[overrideField], newOverrides);
-    return Object.assign({}, packageJson, { [overrideField]: overrides });
+    if (overrideSource.kind !== "manifest") return packageJson;
+    return applyOverridesToSourceConfig(packageJson, overrideSource, overrides);
   }
 
   applyAutoFix(overrides: SecurityOverride[], packageJsonPath?: string): string | void {
@@ -894,7 +887,7 @@ export class SecurityChecker {
     newOverrides: OverridesType,
     overrides: SecurityOverride[],
   ): PastoralistJSON {
-    const updatedPackageJson = applyOverridesToSourceConfig(
+    const updatedPackageJson = this.applyOverridesToPackageJson(
       packageJson,
       overrideSource,
       mergedOverrides,
@@ -960,20 +953,6 @@ export class SecurityChecker {
 
   private writePackageJson(pkgPath: string, packageJson: PastoralistJSON): void {
     writeFileSync(pkgPath, JSON.stringify(packageJson, null, 2) + "\n");
-  }
-
-  private getOverrideField(
-    packageManager: "npm" | "yarn" | "pnpm" | "bun",
-  ): "overrides" | "resolutions" {
-    switch (packageManager) {
-      case "yarn":
-        return "resolutions";
-      case "pnpm":
-      case "npm":
-      case "bun":
-      default:
-        return "overrides";
-    }
   }
 
   rollbackAutoFix(backupPath: string, originalPath: string): void {

--- a/src/core/security/index.ts
+++ b/src/core/security/index.ts
@@ -50,7 +50,7 @@ import { SecuritySetupWizard, promptForSetup } from "./setup";
 import type { SetupSecurityProvider } from "./types";
 import { KNOWN_PROVIDERS, PROVIDER_CONFIGS } from "./constants";
 import { readFileSync, copyFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "fs";
-import { createHash } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { resolve, dirname, basename } from "path";
 import { updateAppendix } from "../appendix";
 import { glob } from "../../utils/glob";
@@ -842,7 +842,8 @@ export class SecurityChecker {
     const root = this.cacheRoot ?? dirname(pkgPath);
     const cacheDir = resolveBackupCacheDir(root, this.configuredCacheDir);
     mkdirSync(cacheDir, { recursive: true });
-    const backupPath = resolve(cacheDir, `${basename(pkgPath)}.backup-${Date.now()}`);
+    const backupName = `${basename(pkgPath)}.backup-${Date.now()}-${randomUUID()}`;
+    const backupPath = resolve(cacheDir, backupName);
     copyFileSync(pkgPath, backupPath);
     pruneBackups(cacheDir);
     this.log.debug(`Created backup at ${backupPath}`, "createBackup");

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,11 +1,5 @@
 import type { execFile } from "node:child_process";
-import type { OverrideValue } from "../types";
 import type { PartialSecurityLedger } from "./appendix/types";
-
-export type OverrideType = {
-  type: string;
-  overrides: Record<string, OverrideValue>;
-};
 
 export type ExecFileAsync = typeof execFile.__promisify__;
 

--- a/src/core/update/index.ts
+++ b/src/core/update/index.ts
@@ -14,7 +14,11 @@ import {
   processWorkspacePackages,
 } from "../workspaces";
 import { attachPatchesToAppendix, detectPatches, findUnusedPatches } from "../patches";
-import { resolveOverrides, getOverridesByType } from "../overrides";
+import {
+  getOverridesByType,
+  resolveOverrideSource,
+  resolveOverridesFromSource,
+} from "../overrides";
 import { updateAppendix, constructAppendix } from "../appendix";
 import { mergeAppendixDependents } from "../appendix/utils";
 import {
@@ -52,10 +56,11 @@ const stepDetectPatches = (ctx: UpdateContext): UpdateContext => {
 const stepPrepareOverrides = (ctx: UpdateContext): UpdateContext => {
   if (!ctx.config) return ctx;
 
-  const overridesData = resolveOverrides({
-    options: ctx.options,
+  const overrideSource = resolveOverrideSource({
     config: ctx.config,
+    manifestPath: ctx.path,
   });
+  const overridesData = resolveOverridesFromSource(overrideSource);
   let overrides = getOverridesByType(overridesData) || {};
 
   if (ctx.options?.securityOverrides) {
@@ -63,7 +68,7 @@ const stepPrepareOverrides = (ctx: UpdateContext): UpdateContext => {
     overrides = Object.assign({}, overrides, ctx.options.securityOverrides);
   }
 
-  return Object.assign({}, ctx, { overridesData, overrides });
+  return Object.assign({}, ctx, { overrideSource, overridesData, overrides });
 };
 
 const stepDetermineMode = (ctx: UpdateContext): UpdateContext => {
@@ -375,10 +380,12 @@ const stepWriteResult = (ctx: UpdateContext): UpdateContext => {
   );
 
   writeResult({
+    appendixTarget: ctx.options.appendixTarget,
     path: ctx.path,
-    config: ctx.config!,
+    config: ctx.options.manifestConfig || ctx.config!,
     finalAppendix: ctx.finalAppendix!,
     finalOverrides: ctx.finalOverrides!,
+    overrideSource: ctx.overrideSource,
     options: ctx.options,
     isTesting: ctx.isTesting,
   });
@@ -460,7 +467,7 @@ const getSecurityDetails = (ctx: UpdateContext): NonNullable<Options["securityOv
   ctx.options?.securityOverrideDetails || [];
 
 const getExistingOverrides = (ctx: UpdateContext): Record<string, unknown> | undefined =>
-  ctx.config?.overrides || ctx.config?.resolutions;
+  ctx.overrideSource?.overrides;
 
 const buildUpdateMetrics = (ctx: UpdateContext): UpdateMetrics => {
   const securityDetails = getSecurityDetails(ctx);

--- a/src/core/update/types.ts
+++ b/src/core/update/types.ts
@@ -1,7 +1,15 @@
-import type { Options, Appendix, OverridesType, PastoralistJSON, SecurityAlert } from "../../types";
+import type {
+  Appendix,
+  AppendixTarget,
+  Options,
+  OverridesType,
+  PastoralistJSON,
+  SecurityAlert,
+} from "../../types";
 import type { PastoralistConfig } from "../../config";
 import type { ResolveOverrides } from "../../types";
 import type { Logger } from "../../utils";
+import type { OverrideSource } from "../overrides";
 
 export interface ProcessingMode {
   mode: "workspace" | "root";
@@ -68,6 +76,7 @@ export interface UpdateContext {
   config?: PastoralistJSON;
   patchMap?: Record<string, string[]>;
   overridesData?: ResolveOverrides;
+  overrideSource?: OverrideSource;
   overrides?: OverridesType;
   hasRootOverrides?: boolean;
   rootDeps?: Record<string, string>;
@@ -99,10 +108,12 @@ export interface UpdateRuntime {
 }
 
 export interface WriteResultContext {
+  appendixTarget?: AppendixTarget;
   path: string;
   config: PastoralistJSON;
   finalAppendix: Appendix;
   finalOverrides: OverridesType;
+  overrideSource?: OverrideSource;
   options: { dryRun?: boolean; outputFormat?: "text" | "json" };
   isTesting: boolean;
 }

--- a/src/core/update/utils.ts
+++ b/src/core/update/utils.ts
@@ -1,5 +1,8 @@
 import { findPackageJsonFiles, updatePackageJSON } from "../package";
+import { writeOverrideSource } from "../overrides";
 import { toCompactAppendix } from "../appendix/utils";
+import { writeTargetAppendix } from "../appendix";
+import { clearConfigCache } from "../../config";
 import { resolveWorkspaceManifestPaths } from "../workspaces";
 import { WORKSPACE_MODES } from "./constants";
 import type {
@@ -30,19 +33,39 @@ const resolveAppendix = (finalAppendix: Appendix, useCompact: boolean): Appendix
   return toCompactAppendix(finalAppendix) as Appendix;
 };
 
+const writeExternalAppendix = (ctx: WriteResultContext, appendix: Appendix): void => {
+  if (!ctx.appendixTarget) return;
+  if (ctx.isTesting) return;
+
+  const dryRun = ctx.options?.dryRun || false;
+  writeTargetAppendix(ctx.appendixTarget, appendix, dryRun);
+  if (!dryRun) clearConfigCache();
+};
+
 export const writeResult = (ctx: WriteResultContext): void => {
   const isJsonOutput = ctx.options?.outputFormat === "json";
   const useCompact = ctx.config?.pastoralist?.compactAppendix === true;
   const appendix = resolveAppendix(ctx.finalAppendix, useCompact);
+  const hasExternalSource = Boolean(ctx.overrideSource && ctx.overrideSource.kind !== "manifest");
+  const packageAppendix = ctx.appendixTarget ? undefined : appendix;
+
+  if (ctx.overrideSource) {
+    writeOverrideSource(ctx.overrideSource, ctx.finalOverrides, {
+      dryRun: ctx.options?.dryRun,
+    });
+  }
+
+  writeExternalAppendix(ctx, appendix);
 
   updatePackageJSON({
-    appendix,
+    appendix: packageAppendix,
     path: ctx.path,
     config: ctx.config,
     overrides: ctx.finalOverrides,
     dryRun: ctx.options?.dryRun || false,
     silent: isJsonOutput,
     isTesting: ctx.isTesting,
+    manageOverrides: !hasExternalSource,
   });
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,13 +35,25 @@ export {
   getOverridesByType,
   updateOverrides,
   defineOverride,
+  applyOverridesToSourceConfig,
+  parsePnpmWorkspaceOverrides,
+  resolveOverrideSource,
+  resolveOverridesFromSource,
+  updatePnpmWorkspaceOverrides,
+  writeOverrideSource,
 } from "./core/overrides";
 
 export { detectPatches, attachPatchesToAppendix, findUnusedPatches } from "./core/patches";
 
 export { SecurityChecker } from "./core/security";
 
-export { loadConfig, loadExternalConfig, mergeConfigs, clearConfigCache } from "./config";
+export {
+  loadConfig,
+  loadConfigWithSource,
+  loadExternalConfig,
+  mergeConfigs,
+  clearConfigCache,
+} from "./config";
 
 export { logger } from "./utils";
 
@@ -61,6 +73,8 @@ export type {
   SecurityOverride,
   SecurityProvider,
 } from "./types";
+
+export type { OverrideSource, OverrideSourceKind } from "./core/overrides";
 
 import { realpathSync } from "fs";
 import { fileURLToPath } from "url";

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface PastoralistJSON {
   peerDependencies?: Record<string, string>;
   name: string;
   version: string;
+  packageManager?: string;
   resolutions?: Record<string, string>;
   overrides?: Record<string, OverrideValue>;
   pnpm?: { overrides?: Record<string, OverrideValue> };
@@ -64,8 +65,10 @@ export interface Appendix {
 
 export interface PastoralistConfig {
   appendix?: Appendix;
+  appendixSource?: string;
   compactAppendix?: boolean;
   depPaths?: "workspace" | "workspaces" | string[];
+  overrideSource?: string;
   checkSecurity?: boolean;
   overridePaths?: Record<string, Appendix>;
   resolutionPaths?: Record<string, Appendix>;
@@ -81,6 +84,10 @@ export interface PastoralistConfig {
     strict?: boolean;
     preferLatest?: boolean;
   };
+}
+
+export interface AppendixTarget {
+  path: string;
 }
 
 export interface OverridesConfig {
@@ -176,6 +183,7 @@ export interface PathOptions {
 
 export interface Options extends SecurityOptions, OutputOptions, TestingOptions, PathOptions {
   appendix?: Appendix;
+  appendixTarget?: AppendixTarget;
   clearCache?: boolean;
   help?: boolean;
   version?: boolean;
@@ -185,6 +193,7 @@ export interface Options extends SecurityOptions, OutputOptions, TestingOptions,
   promptForReasons?: boolean;
   manualOverrideReasons?: Record<string, string>;
   config?: PastoralistJSON;
+  manifestConfig?: PastoralistJSON;
   setupHook?: boolean;
   addedDate?: string;
   removeUnused?: boolean;
@@ -209,6 +218,7 @@ export interface UpdatePackageJSONOptions {
   config: PastoralistJSON;
   overrides?: OverridesType;
   isTesting?: boolean;
+  manageOverrides?: boolean;
 }
 
 export interface FindRootDeps {

--- a/tests/e2e/Dockerfile.external-config
+++ b/tests/e2e/Dockerfile.external-config
@@ -1,0 +1,19 @@
+FROM node:24-alpine
+
+RUN apk add --no-cache bash jq
+
+WORKDIR /app
+
+COPY dist/ ./pastoralist/
+COPY package.json ./pastoralist/package.json
+RUN chmod +x ./pastoralist/index.js
+RUN node ./pastoralist/index.js --help >/dev/null
+
+COPY tests/e2e/fixtures/external-config/ ./fixtures/
+COPY tests/e2e/scripts/test-external-config-ledger.sh ./test.sh
+RUN chmod +x ./test.sh
+
+ENV NODE_ENV=test
+ENV IS_DEBUGGING=false
+
+CMD ["/app/test.sh"]

--- a/tests/e2e/Dockerfile.pnpm-yaml
+++ b/tests/e2e/Dockerfile.pnpm-yaml
@@ -1,0 +1,20 @@
+FROM node:24-alpine
+
+RUN apk add --no-cache bash jq
+RUN corepack enable && corepack prepare pnpm@11.0.0 --activate
+
+WORKDIR /app
+
+COPY dist/ ./pastoralist/
+COPY package.json ./pastoralist/package.json
+RUN chmod +x ./pastoralist/index.js
+RUN node ./pastoralist/index.js --help >/dev/null
+
+COPY tests/e2e/fixtures/pnpm-yaml/ ./fixtures/
+COPY tests/e2e/scripts/test-pnpm-yaml.sh ./test.sh
+RUN chmod +x ./test.sh
+
+ENV NODE_ENV=test
+ENV IS_DEBUGGING=false
+
+CMD ["/app/test.sh"]

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -1,6 +1,22 @@
 version: "3.8"
 
 services:
+  e2e-pnpm-yaml:
+    build:
+      context: ../..
+      dockerfile: tests/e2e/Dockerfile.pnpm-yaml
+    environment:
+      - NODE_ENV=test
+      - IS_DEBUGGING=false
+
+  e2e-external-config:
+    build:
+      context: ../..
+      dockerfile: tests/e2e/Dockerfile.external-config
+    environment:
+      - NODE_ENV=test
+      - IS_DEBUGGING=false
+
   # Test with pnpm
   e2e-pnpm:
     build:

--- a/tests/e2e/fixtures/external-config/.pastoralistrc
+++ b/tests/e2e/fixtures/external-config/.pastoralistrc
@@ -1,0 +1,6 @@
+{
+  "security": {
+    "enabled": false,
+    "provider": "osv"
+  }
+}

--- a/tests/e2e/fixtures/external-config/package.json
+++ b/tests/e2e/fixtures/external-config/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pastoralist-external-config-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "lodash": "^4.17.20"
+  },
+  "overrides": {
+    "lodash": "4.17.21"
+  }
+}

--- a/tests/e2e/fixtures/external-config/package.json
+++ b/tests/e2e/fixtures/external-config/package.json
@@ -2,7 +2,7 @@
   "name": "pastoralist-external-config-e2e",
   "version": "1.0.0",
   "private": true,
-  "dependencies": {
+  "devDependencies": {
     "lodash": "^4.17.20"
   },
   "overrides": {

--- a/tests/e2e/fixtures/pnpm-yaml/package.json
+++ b/tests/e2e/fixtures/pnpm-yaml/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pastoralist-pnpm-yaml-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "postinstall": "node /app/pastoralist/index.js --outputFormat json"
+  },
+  "dependencies": {
+    "lodash": "4.17.20"
+  },
+  "packageManager": "pnpm@11.0.0"
+}

--- a/tests/e2e/fixtures/pnpm-yaml/package.json
+++ b/tests/e2e/fixtures/pnpm-yaml/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "postinstall": "node /app/pastoralist/index.js --outputFormat json"
   },
-  "dependencies": {
+  "devDependencies": {
     "lodash": "4.17.20"
   },
   "packageManager": "pnpm@11.0.0"

--- a/tests/e2e/fixtures/pnpm-yaml/pnpm-workspace.yaml
+++ b/tests/e2e/fixtures/pnpm-yaml/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+# retained YAML comment
+overrides:
+  lodash: "4.17.21"

--- a/tests/e2e/scripts/run-e2e-tests.sh
+++ b/tests/e2e/scripts/run-e2e-tests.sh
@@ -19,6 +19,8 @@ if [ ! -f /.dockerenv ]; then
     
     echo "🧪 Running E2E tests..."
     docker compose up --abort-on-container-exit e2e-pnpm
+    docker compose run --rm e2e-pnpm-yaml
+    docker compose run --rm e2e-external-config
 
     TEST_EXIT_CODE=$?
     

--- a/tests/e2e/scripts/test-external-config-ledger.sh
+++ b/tests/e2e/scripts/test-external-config-ledger.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+project_dir="/tmp/pastoralist-external-config-e2e"
+mkdir -p "$project_dir"
+cp /app/fixtures/package.json "$project_dir/package.json"
+cp /app/fixtures/.pastoralistrc "$project_dir/.pastoralistrc"
+cd "$project_dir"
+
+node /app/pastoralist/index.js --outputFormat json
+
+jq -e '.pastoralist == null' package.json >/dev/null
+jq -e '.overrides.lodash == "4.17.21"' package.json >/dev/null
+jq -e '.security == {"enabled": false, "provider": "osv"}' .pastoralistrc >/dev/null
+jq -e '.appendix["lodash@4.17.21"]' .pastoralistrc >/dev/null
+test -z "$(find "$project_dir" -maxdepth 1 -name '*.tmp' -print -quit)"
+
+cp .pastoralistrc .pastoralistrc.after-first-run
+node /app/pastoralist/index.js --outputFormat json
+cmp .pastoralistrc.after-first-run .pastoralistrc
+
+echo "external config ledger E2E passed"

--- a/tests/e2e/scripts/test-pnpm-yaml.sh
+++ b/tests/e2e/scripts/test-pnpm-yaml.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+project_dir="/tmp/pastoralist-pnpm-yaml-e2e"
+mkdir -p "$project_dir"
+cp /app/fixtures/package.json "$project_dir/package.json"
+cp /app/fixtures/pnpm-workspace.yaml "$project_dir/pnpm-workspace.yaml"
+cp "$project_dir/pnpm-workspace.yaml" "$project_dir/pnpm-workspace.before.yaml"
+cd "$project_dir"
+
+pnpm_version="$(pnpm --version)"
+test "${pnpm_version%%.*}" = "11"
+
+pnpm install
+
+installed_lodash="$(node -p "require('./node_modules/lodash/package.json').version")"
+test "$installed_lodash" = "4.17.21"
+cmp pnpm-workspace.before.yaml pnpm-workspace.yaml
+jq -e '.pastoralist.appendix["lodash@4.17.21"]' package.json >/dev/null
+jq -e '(.pnpm.overrides // null) == null' package.json >/dev/null
+
+output="$(node /app/pastoralist/index.js --dry-run --outputFormat json)"
+result="$(printf '%s\n' "$output" | tail -n 1)"
+test "$(printf '%s' "$result" | jq -r '.overrideCount')" = "1"
+test "$(printf '%s' "$result" | jq -r '.appliedOverrides.lodash')" = "4.17.21"
+
+echo "pnpm YAML override E2E passed"

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -1,11 +1,12 @@
 import { test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, readdirSync } from "fs";
 import { resolve, join } from "path";
 import { action } from "../../src/cli/index";
 import type { Options, KeepConstraint } from "../../src/types";
 import * as packageJSON from "../../src/core/package";
 import { clearOSVCache } from "../../src/core/security/providers/osv";
 import { clearRegistryCache } from "../../src/utils/npm";
+import { clearConfigCache } from "../../src/config";
 
 const TEST_DIR = resolve(__dirname, ".test-e2e-cli");
 
@@ -22,6 +23,7 @@ beforeEach(() => {
   }
   mkdirSync(TEST_DIR, { recursive: true });
   packageJSON.clearDependencyTreeCache();
+  clearConfigCache();
   clearOSVCache();
   clearRegistryCache();
 });
@@ -158,6 +160,34 @@ test("e2e: handles pnpm overrides", async () => {
   expect(result.pastoralist.appendix).toBeDefined();
 });
 
+test("e2e: reports pnpm workspace YAML overrides in dry-run JSON output", async () => {
+  const pkgPath = createFixture("pnpm-workspace-yaml-overrides", {
+    name: "test-pnpm-yaml",
+    version: "1.0.0",
+    packageManager: "pnpm@11.0.0",
+    dependencies: {
+      lodash: "^4.17.20",
+    },
+  });
+  const root = resolve(pkgPath, "..");
+  const workspacePath = join(root, "pnpm-workspace.yaml");
+  const workspace = '# workspace\noverrides:\n  lodash: "4.17.21"\n';
+  writeFileSync(workspacePath, workspace);
+
+  const result = await action({
+    path: pkgPath,
+    root,
+    checkSecurity: false,
+    dryRun: true,
+    outputFormat: "json",
+    isTesting: true,
+  });
+
+  expect(result.overrideCount).toBe(1);
+  expect(result.appliedOverrides).toEqual({ lodash: "4.17.21" });
+  expect(readFileSync(workspacePath, "utf8")).toBe(workspace);
+});
+
 test("e2e: preserves existing pastoralist config", async () => {
   const pkgPath = createFixture("existing-config", {
     name: "test-existing",
@@ -182,6 +212,78 @@ test("e2e: preserves existing pastoralist config", async () => {
   expect(result.pastoralist.security).toBeDefined();
   expect(result.pastoralist.security.enabled).toBe(false);
   expect(result.pastoralist.security.provider).toBe("osv");
+});
+
+test("e2e: writes the appendix back to an external JSON config", async () => {
+  const pkgPath = createFixture("external-json-ledger", {
+    name: "test-external-json-ledger",
+    version: "1.0.0",
+    dependencies: { lodash: "^4.17.20" },
+    overrides: { lodash: "4.17.21" },
+  });
+  const root = resolve(pkgPath, "..");
+  const configPath = join(root, ".pastoralistrc");
+  const externalConfig = { security: { enabled: false, provider: "osv" } };
+  writeFileSync(configPath, JSON.stringify(externalConfig, null, 2));
+
+  await action({ path: pkgPath, root, checkSecurity: false });
+
+  const packageJson = JSON.parse(readFileSync(pkgPath, "utf8"));
+  const config = JSON.parse(readFileSync(configPath, "utf8"));
+  const temporaryFiles = readdirSync(root).filter((filename) => filename.endsWith(".tmp"));
+  expect(packageJson.pastoralist).toBeUndefined();
+  expect(packageJson.overrides).toEqual({ lodash: "4.17.21" });
+  expect(config.security).toEqual(externalConfig.security);
+  expect(config.appendix["lodash@4.17.21"]).toBeDefined();
+  expect(temporaryFiles).toEqual([]);
+
+  const firstWrite = readFileSync(configPath, "utf8");
+  await action({ path: pkgPath, root, checkSecurity: false });
+  expect(readFileSync(configPath, "utf8")).toBe(firstWrite);
+});
+
+test("e2e: keeps JavaScript config read-only and writes the appendix to package.json", async () => {
+  const pkgPath = createFixture("javascript-config-ledger", {
+    name: "test-javascript-config-ledger",
+    version: "1.0.0",
+    dependencies: { lodash: "^4.17.20" },
+    overrides: { lodash: "4.17.21" },
+  });
+  const root = resolve(pkgPath, "..");
+  const configPath = join(root, "pastoralist.config.cjs");
+  const source = 'module.exports = { security: { enabled: false, provider: "osv" } };\n';
+  writeFileSync(configPath, source);
+
+  await action({ path: pkgPath, root, checkSecurity: false });
+
+  const packageJson = JSON.parse(readFileSync(pkgPath, "utf8"));
+  expect(readFileSync(configPath, "utf8")).toBe(source);
+  expect(packageJson.pastoralist.appendix["lodash@4.17.21"]).toBeDefined();
+});
+
+test("e2e: honors an explicit appendix source for JavaScript config", async () => {
+  const pkgPath = createFixture("javascript-config-external-ledger", {
+    name: "test-javascript-config-external-ledger",
+    version: "1.0.0",
+    dependencies: { lodash: "^4.17.20" },
+    overrides: { lodash: "4.17.21" },
+  });
+  const root = resolve(pkgPath, "..");
+  const configPath = join(root, "pastoralist.config.cjs");
+  const appendixPath = join(root, "ledger.json");
+  const source =
+    'module.exports = { appendixSource: "ledger.json", security: { enabled: false } };\n';
+  writeFileSync(configPath, source);
+  writeFileSync(appendixPath, JSON.stringify({ checkSecurity: false }, null, 2));
+
+  await action({ path: pkgPath, root, checkSecurity: false });
+
+  const packageJson = JSON.parse(readFileSync(pkgPath, "utf8"));
+  const appendixConfig = JSON.parse(readFileSync(appendixPath, "utf8"));
+  expect(readFileSync(configPath, "utf8")).toBe(source);
+  expect(packageJson.pastoralist).toBeUndefined();
+  expect(appendixConfig.checkSecurity).toBe(false);
+  expect(appendixConfig.appendix["lodash@4.17.21"]).toBeDefined();
 });
 
 test("e2e: dry-run does not modify package.json", async () => {

--- a/tests/integration/index.test.ts
+++ b/tests/integration/index.test.ts
@@ -2,6 +2,8 @@ import { test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "fs";
 import { resolve } from "path";
 import { update } from "../../src/core/update";
+import { writeResult } from "../../src/core/update/utils";
+import { resolveOverrideSource } from "../../src/core/overrides";
 import type { Options } from "../../src/types";
 
 const TEST_DIR = resolve(__dirname, ".test-integration");
@@ -69,6 +71,54 @@ test("update - should process package.json with overrides", () => {
   expect(result.appendix?.["lodash@4.17.21"]).toBeDefined();
   expect(result.overrides).toBeDefined();
   expect(result.overrides?.lodash).toBe("4.17.21");
+});
+
+test("update - should build the ledger from pnpm workspace overrides", () => {
+  createTestPackageJson({
+    packageManager: "pnpm@11.0.0",
+  });
+  writeFileSync(resolve(TEST_DIR, "pnpm-workspace.yaml"), 'overrides:\n  lodash: "4.17.21"\n');
+
+  const config = JSON.parse(readFileSync(TEST_PACKAGE_JSON, "utf8"));
+  const result = update({
+    path: TEST_PACKAGE_JSON,
+    root: TEST_DIR,
+    config,
+    isTesting: true,
+  });
+
+  expect(result.overrideSource?.kind).toBe("yaml");
+  expect(result.overrides).toEqual({ lodash: "4.17.21" });
+  expect(result.appendix?.["lodash@4.17.21"]).toBeDefined();
+});
+
+test("writeResult - should keep pnpm overrides outside package.json", () => {
+  createTestPackageJson({
+    packageManager: "pnpm@11.0.0",
+    pastoralist: { overrideSource: "pnpm-workspace.yaml" },
+  });
+  const workspacePath = resolve(TEST_DIR, "pnpm-workspace.yaml");
+  writeFileSync(workspacePath, '# retained\noverrides:\n  lodash: "4.17.20"\n');
+  const config = JSON.parse(readFileSync(TEST_PACKAGE_JSON, "utf8"));
+  const overrideSource = resolveOverrideSource({ config, manifestPath: TEST_PACKAGE_JSON });
+
+  writeResult({
+    path: TEST_PACKAGE_JSON,
+    config,
+    finalAppendix: { "lodash@4.17.21": { ledger: { addedDate: "2026-08-08" } } },
+    finalOverrides: { lodash: "4.17.21" },
+    overrideSource,
+    options: {},
+    isTesting: false,
+  });
+
+  const packageJson = JSON.parse(readFileSync(TEST_PACKAGE_JSON, "utf8"));
+  const workspace = readFileSync(workspacePath, "utf8");
+  expect(packageJson.pnpm).toBeUndefined();
+  expect(packageJson.overrides).toBeUndefined();
+  expect(packageJson.pastoralist.appendix["lodash@4.17.21"]).toBeDefined();
+  expect(workspace).toContain("# retained");
+  expect(workspace).toContain('lodash: "4.17.21"');
 });
 
 test("update - should detect and attach patches", () => {

--- a/tests/unit/cli/index.test.ts
+++ b/tests/unit/cli/index.test.ts
@@ -13,6 +13,23 @@ import {
 
 const log = createLogger({ file: "test.ts", isLogging: false });
 const actionExternalConfigDir = resolve(__dirname, "..", ".test-action-external-config");
+const EXTERNAL_OVERRIDE_CONFIG: PastoralistJSON = {
+  name: "test-app",
+  version: "1.0.0",
+  pastoralist: { overrideSource: "overrides.json" },
+};
+const EXTERNAL_OVERRIDE_OPTIONS: Options = {
+  forceSecurityRefactor: true,
+  path: "package.json",
+  config: EXTERNAL_OVERRIDE_CONFIG,
+};
+const CLI_SECURITY_OVERRIDE = {
+  packageName: "lodash",
+  fromVersion: "4.17.20",
+  toVersion: "4.17.21",
+  reason: "Security fix",
+  severity: "high",
+};
 
 const createMockTerminalGraph = () => {
   const graph = {
@@ -386,6 +403,26 @@ test("handleSecurityResults - generates overrides when alerts found", () => {
   expect(mockSecurityChecker.generatePackageOverrides).toHaveBeenCalled();
   expect(mockSecurityChecker.applyAutoFix).toHaveBeenCalled();
   expect(result.securityOverrides).toEqual({ lodash: "4.17.21" });
+});
+
+test("handleSecurityResults - passes merged config to auto-fix", () => {
+  const { handleSecurityResults } = require("../../../src/cli/index");
+  const applyAutoFix = mock();
+  const generatePackageOverrides = mock(() => ({ lodash: "4.17.21" }));
+  const checker = { applyAutoFix, generatePackageOverrides };
+
+  handleSecurityResults(
+    [{} as any],
+    [CLI_SECURITY_OVERRIDE],
+    checker as any,
+    { stop: mock() } as any,
+    EXTERNAL_OVERRIDE_OPTIONS,
+  );
+  expect(applyAutoFix).toHaveBeenCalledWith(
+    [CLI_SECURITY_OVERRIDE],
+    "package.json",
+    EXTERNAL_OVERRIDE_CONFIG,
+  );
 });
 
 test("handleSecurityResults - generates overrides in interactive mode", () => {

--- a/tests/unit/config/index.test.ts
+++ b/tests/unit/config/index.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 import { resolve } from "path";
 import {
   loadConfig,
+  loadConfigWithSource,
   loadExternalConfig,
   mergeConfigs,
   clearConfigCache,
@@ -150,6 +151,21 @@ test("loadExternalConfig - should load JSON config file", async () => {
   if (existsSync(testDir)) {
     rmSync(testDir, { recursive: true, force: true });
   }
+  validateRootPackageJsonIntegrity();
+});
+
+test("loadConfigWithSource - tracks a writable JSON appendix target", async () => {
+  validateRootPackageJsonIntegrity();
+  mkdirSync(testDir, { recursive: true });
+  const configPath = resolve(testDir, ".pastoralistrc.json");
+  writeFileSync(configPath, JSON.stringify({ checkSecurity: false }));
+
+  clearConfigCache();
+  const loaded = await loadConfigWithSource(testDir);
+
+  expect(loaded.source).toEqual({ format: "json", path: configPath });
+  expect(loaded.appendixTarget).toEqual({ path: configPath });
+  rmSync(testDir, { recursive: true, force: true });
   validateRootPackageJsonIntegrity();
 });
 

--- a/tests/unit/config/index.test.ts
+++ b/tests/unit/config/index.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 import { resolve } from "path";
 import {
   loadConfig,
+  loadCliConfig,
   loadConfigWithSource,
   loadExternalConfig,
   mergeConfigs,
@@ -10,6 +11,7 @@ import {
   safeValidateConfig,
 } from "../../../src/config";
 import type { PastoralistConfig } from "../../../src/config";
+import type { CliConfigDeps } from "../../../src/cli/types";
 import {
   safeWriteFileSync as writeFileSync,
   safeMkdirSync as mkdirSync,
@@ -167,6 +169,40 @@ test("loadConfigWithSource - tracks a writable JSON appendix target", async () =
   expect(loaded.appendixTarget).toEqual({ path: configPath });
   rmSync(testDir, { recursive: true, force: true });
   validateRootPackageJsonIntegrity();
+});
+
+test("loadConfigWithSource - merges an explicit target appendix", async () => {
+  validateRootPackageJsonIntegrity();
+  mkdirSync(testDir, { recursive: true });
+  const configPath = resolve(testDir, "ledger.json");
+  const appendix = { "lodash@4.17.21": { dependents: { app: "lodash@^4" } } };
+  writeFileSync(configPath, JSON.stringify({ appendix }));
+
+  clearConfigCache();
+  const loaded = await loadConfigWithSource(testDir, { appendixSource: "ledger.json" });
+
+  expect(loaded.appendixTarget).toEqual({ path: configPath });
+  expect(loaded.config?.appendix).toEqual(appendix);
+  rmSync(testDir, { recursive: true, force: true });
+  validateRootPackageJsonIntegrity();
+});
+
+test("loadCliConfig - uses source-aware config loading", async () => {
+  const packageConfig = { name: "app", version: "1.0.0", pastoralist: {} };
+  const deps: CliConfigDeps = {
+    resolveJSON: () => packageConfig,
+    buildMergedOptions: () => ({}),
+    loadConfigWithSource: async () => ({
+      appendixTarget: { path: "ledger.json" },
+      config: {},
+      source: undefined,
+    }),
+  };
+
+  const loaded = await loadCliConfig({}, {}, deps);
+
+  expect(loaded.appendixTarget).toEqual({ path: "ledger.json" });
+  expect(loaded.manifestConfig).toEqual(packageConfig);
 });
 
 test("loadExternalConfig - should handle invalid JSON", async () => {

--- a/tests/unit/config/validation.test.ts
+++ b/tests/unit/config/validation.test.ts
@@ -237,6 +237,30 @@ test("validateConfig - should reject invalid checkSecurity type", () => {
   expect(() => validateConfig(config)).toThrow("Invalid config structure");
 });
 
+test("validateConfig - should accept an explicit override source", () => {
+  const config = { overrideSource: "config/pnpm-overrides.yaml" };
+
+  expect(validateConfig(config)).toEqual(config);
+});
+
+test("validateConfig - should reject a non-string override source", () => {
+  expect(() => validateConfig({ overrideSource: ["pnpm-workspace.yaml"] })).toThrow(
+    "Invalid config structure",
+  );
+});
+
+test("validateConfig - should accept an explicit appendix source", () => {
+  const config = { appendixSource: "config/ledger.json" };
+
+  expect(validateConfig(config)).toEqual(config);
+});
+
+test("validateConfig - should reject a non-string appendix source", () => {
+  expect(() => validateConfig({ appendixSource: ["ledger.json"] })).toThrow(
+    "Invalid config structure",
+  );
+});
+
 test("validateConfig - should accept valid overridePaths", () => {
   const config = {
     overridePaths: {

--- a/tests/unit/core/appendix.test.ts
+++ b/tests/unit/core/appendix.test.ts
@@ -5,6 +5,9 @@ import {
   updateAppendix,
   processAndWritePackageJSON,
   constructAppendix,
+  loadTargetAppendix,
+  resolveAppendixTarget,
+  writeTargetAppendix,
 } from "../../../src/core/appendix";
 import {
   findUnusedAppendixEntries,
@@ -27,6 +30,69 @@ afterEach(() => {
   if (existsSync(TEST_DIR)) {
     rmSync(TEST_DIR, { recursive: true, force: true });
   }
+});
+
+test("resolveAppendixTarget - resolves JSON targets", () => {
+  const jsonSource = { format: "json" as const, path: resolve(TEST_DIR, "config.json") };
+
+  expect(resolveAppendixTarget({ appendixSource: "ledger.json" }, undefined, TEST_DIR)).toEqual({
+    path: resolve(TEST_DIR, "ledger.json"),
+  });
+  expect(resolveAppendixTarget({ appendixSource: ".pastoralistrc" }, undefined, TEST_DIR)).toEqual({
+    path: resolve(TEST_DIR, ".pastoralistrc"),
+  });
+  expect(resolveAppendixTarget({}, jsonSource, TEST_DIR)).toEqual({ path: jsonSource.path });
+  expect(
+    resolveAppendixTarget({}, { format: "javascript", path: "config.js" }, TEST_DIR),
+  ).toBeUndefined();
+});
+
+test("resolveAppendixTarget - rejects non-JSON targets", () => {
+  expect(() => resolveAppendixTarget({ appendixSource: "ledger.js" }, undefined, TEST_DIR)).toThrow(
+    "Appendix source must be a JSON config file",
+  );
+});
+
+test("loadTargetAppendix - reads existing targets", () => {
+  const path = resolve(TEST_DIR, "ledger.json");
+  const appendix = { "lodash@4.17.21": { dependents: { app: "lodash@^4" } } };
+  writeFileSync(path, JSON.stringify({ appendix }));
+
+  expect(loadTargetAppendix(undefined)).toBeUndefined();
+  expect(loadTargetAppendix({ path: resolve(TEST_DIR, "missing.json") })).toBeUndefined();
+  expect(loadTargetAppendix({ path })).toEqual(appendix);
+});
+
+test("writeTargetAppendix - creates a target and its parent", () => {
+  const path = resolve(TEST_DIR, "config", "ledger.json");
+  const appendix = { "lodash@4.17.21": { dependents: { app: "lodash@^4" } } };
+
+  writeTargetAppendix({ path }, appendix, false);
+
+  expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({ appendix });
+});
+
+test("writeTargetAppendix - preserves config and removes an empty appendix", () => {
+  const path = resolve(TEST_DIR, "ledger.json");
+  writeFileSync(path, JSON.stringify({ checkSecurity: true, appendix: { stale: {} } }));
+
+  writeTargetAppendix({ path }, {}, false);
+
+  expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({ checkSecurity: true });
+});
+
+test("writeTargetAppendix - skips dry runs", () => {
+  const path = resolve(TEST_DIR, "ledger.json");
+
+  writeTargetAppendix({ path }, {}, true);
+
+  expect(existsSync(path)).toBe(false);
+});
+
+test("writeTargetAppendix - cleans up failed atomic writes", () => {
+  const path = resolve(TEST_DIR, "x".repeat(300));
+
+  expect(() => writeTargetAppendix({ path }, {}, false)).toThrow();
 });
 
 test("updateAppendix - should handle empty overrides", () => {

--- a/tests/unit/core/overrides.test.ts
+++ b/tests/unit/core/overrides.test.ts
@@ -195,6 +195,32 @@ test("parsePnpmWorkspaceOverrides - reads top-level pnpm overrides", () => {
   });
 });
 
+test("parsePnpmWorkspaceOverrides - reads unquoted flow mappings", () => {
+  const content = "overrides: { lodash: 4.17.21, react: '18.3.1', foo@npm:bar@1: 2.0.0 }\n";
+
+  expect(parsePnpmWorkspaceOverrides(content)).toEqual({
+    lodash: "4.17.21",
+    react: "18.3.1",
+    "foo@npm:bar@1": "2.0.0",
+  });
+});
+
+test("parsePnpmWorkspaceOverrides - reads nested block mappings", () => {
+  const content = [
+    "overrides:",
+    "  foo:",
+    "    bar: 1.2.3",
+    '    baz: "2.0.0"',
+    "  lodash: 4.17.21",
+    "",
+  ].join("\n");
+
+  expect(parsePnpmWorkspaceOverrides(content)).toEqual({
+    foo: { bar: "1.2.3", baz: "2.0.0" },
+    lodash: "4.17.21",
+  });
+});
+
 test("updatePnpmWorkspaceOverrides - preserves comments and existing order", () => {
   const content = [
     "# workspace settings",
@@ -221,6 +247,40 @@ test("updatePnpmWorkspaceOverrides - preserves comments and existing order", () 
   expect(updated.indexOf("lodash:")).toBeLessThan(updated.indexOf("react:"));
   expect(updated.indexOf("react:")).toBeLessThan(updated.indexOf('"zod":'));
   expect(updated.indexOf('"zod":')).toBeLessThan(updated.indexOf("catalog:"));
+});
+
+test("updatePnpmWorkspaceOverrides - preserves unchanged nested block mappings", () => {
+  const content = ["overrides:", "  foo:", "    bar: 1.2.3", "  lodash: 4.17.20", ""].join("\n");
+  const updated = updatePnpmWorkspaceOverrides(content, {
+    foo: { bar: "1.2.3" },
+    lodash: "4.17.21",
+  });
+
+  expect(updated).toContain("  foo:\n    bar: 1.2.3");
+  expect(updated).toContain("  lodash: 4.17.21");
+  expect(parsePnpmWorkspaceOverrides(updated)).toEqual({
+    foo: { bar: "1.2.3" },
+    lodash: "4.17.21",
+  });
+});
+
+test("updatePnpmWorkspaceOverrides - removes nested entries as one block", () => {
+  const content = [
+    "overrides:",
+    "  foo:",
+    "    bar: 1.2.3",
+    "# retained comment",
+    "    baz: 2.0.0",
+    "  lodash: 4.17.20",
+    "",
+  ].join("\n");
+  const updated = updatePnpmWorkspaceOverrides(content, { lodash: "4.17.21" });
+
+  expect(updated).not.toContain("foo:");
+  expect(updated).not.toContain("bar:");
+  expect(updated).not.toContain("baz:");
+  expect(updated).toContain("# retained comment");
+  expect(parsePnpmWorkspaceOverrides(updated)).toEqual({ lodash: "4.17.21" });
 });
 
 test("resolveOverrideSource - selects pnpm-workspace.yaml for pnpm 11", () => {

--- a/tests/unit/core/overrides.test.ts
+++ b/tests/unit/core/overrides.test.ts
@@ -1,10 +1,17 @@
 import { test, expect } from "bun:test";
-import type { OverridesConfig } from "../../../src/types";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { OverridesConfig, PastoralistJSON } from "../../../src/types";
 import {
   defineOverride,
   getOverridesByType,
+  parsePnpmWorkspaceOverrides,
+  resolveOverrideSource,
   resolveOverrides,
+  updatePnpmWorkspaceOverrides,
   updateOverrides,
+  writeOverrideSource,
 } from "../../../src/core/overrides";
 
 test("defineOverride - should return npm overrides when only overrides exist", () => {
@@ -170,4 +177,92 @@ test("resolveOverrides - should return undefined when type is missing", () => {
   const result = resolveOverrides({ config: {}, type: undefined as any });
 
   expect(result).toBeUndefined();
+});
+
+test("parsePnpmWorkspaceOverrides - reads top-level pnpm overrides", () => {
+  const content = [
+    "packages:",
+    '  - "packages/*"',
+    "overrides:",
+    '  lodash: "4.17.21"',
+    "  react: 18.3.1",
+    "",
+  ].join("\n");
+
+  expect(parsePnpmWorkspaceOverrides(content)).toEqual({
+    lodash: "4.17.21",
+    react: "18.3.1",
+  });
+});
+
+test("updatePnpmWorkspaceOverrides - preserves comments and existing order", () => {
+  const content = [
+    "# workspace settings",
+    "packages:",
+    '  - "packages/*"',
+    "overrides:",
+    "  # security pin",
+    "  lodash: 4.17.20 # CVE pin",
+    '  react: "18.3.1"',
+    "catalog:",
+    "  typescript: 7.0.2",
+    "",
+  ].join("\n");
+  const updated = updatePnpmWorkspaceOverrides(content, {
+    lodash: "4.17.21",
+    react: "18.3.1",
+    zod: "4.0.0",
+  });
+
+  expect(updated).toContain("# workspace settings");
+  expect(updated).toContain("# security pin");
+  expect(updated).toContain("lodash: 4.17.21 # CVE pin");
+  expect(updated).toContain('react: "18.3.1"');
+  expect(updated.indexOf("lodash:")).toBeLessThan(updated.indexOf("react:"));
+  expect(updated.indexOf("react:")).toBeLessThan(updated.indexOf('"zod":'));
+  expect(updated.indexOf('"zod":')).toBeLessThan(updated.indexOf("catalog:"));
+});
+
+test("resolveOverrideSource - selects pnpm-workspace.yaml for pnpm 11", () => {
+  const root = mkdtempSync(join(tmpdir(), "pastoralist-overrides-"));
+  const manifestPath = join(root, "package.json");
+  const config: PastoralistJSON = {
+    name: "pnpm-project",
+    version: "1.0.0",
+    packageManager: "pnpm@11.0.0",
+  };
+  writeFileSync(manifestPath, JSON.stringify(config));
+  writeFileSync(join(root, "pnpm-workspace.yaml"), 'overrides:\n  lodash: "4.17.21"\n');
+
+  const source = resolveOverrideSource({ config, manifestPath });
+
+  expect(source.kind).toBe("yaml");
+  expect(source.overrides).toEqual({ lodash: "4.17.21" });
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("writeOverrideSource - writes an explicit YAML source without changing comments", () => {
+  const root = mkdtempSync(join(tmpdir(), "pastoralist-custom-overrides-"));
+  const sourceDir = join(root, "config");
+  const manifestPath = join(root, "package.json");
+  const sourcePath = join(sourceDir, "pins.yaml");
+  const config: PastoralistJSON = {
+    name: "custom-source",
+    version: "1.0.0",
+    pastoralist: { overrideSource: "config/pins.yaml" },
+  };
+  mkdirSync(sourceDir, { recursive: true });
+  writeFileSync(manifestPath, JSON.stringify(config));
+  writeFileSync(sourcePath, '# retained\noverrides:\n  lodash: "4.17.20"\n');
+
+  const source = resolveOverrideSource({ config, manifestPath });
+  writeOverrideSource(source, { lodash: "4.17.21", zod: "4.0.0" });
+  const updated = readFileSync(sourcePath, "utf8");
+
+  expect(updated).toContain("# retained");
+  expect(parsePnpmWorkspaceOverrides(updated)).toEqual({
+    lodash: "4.17.21",
+    zod: "4.0.0",
+  });
+  rmSync(root, { recursive: true, force: true });
 });

--- a/tests/unit/core/overrides.test.ts
+++ b/tests/unit/core/overrides.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import type { OverridesConfig, PastoralistJSON } from "../../../src/types";
 import {
   defineOverride,
+  applyOverridesToSourceConfig,
   getOverridesByType,
   parsePnpmWorkspaceOverrides,
   resolveOverrideSource,
@@ -221,6 +222,31 @@ test("parsePnpmWorkspaceOverrides - reads nested block mappings", () => {
   });
 });
 
+test("parsePnpmWorkspaceOverrides - reads nested flow mappings", () => {
+  const content = "overrides: { foo: { bar: 1.2.3, baz: '2.0.0' }, lodash: 4.17.21 }\n";
+
+  expect(parsePnpmWorkspaceOverrides(content)).toEqual({
+    foo: { bar: "1.2.3", baz: "2.0.0" },
+    lodash: "4.17.21",
+  });
+});
+
+test("parsePnpmWorkspaceOverrides - rejects deeply nested flow mappings", () => {
+  const content = "overrides: { foo: { bar: { baz: 1.2.3 } } }\n";
+
+  expect(() => parsePnpmWorkspaceOverrides(content)).toThrow(
+    "nested pnpm overrides must contain string values",
+  );
+});
+
+test("parsePnpmWorkspaceOverrides - rejects deeply nested block mappings", () => {
+  const content = ["overrides:", "  foo:", "    bar: { baz: 1.2.3 }", ""].join("\n");
+
+  expect(() => parsePnpmWorkspaceOverrides(content)).toThrow(
+    "nested pnpm overrides must contain string values",
+  );
+});
+
 test("updatePnpmWorkspaceOverrides - preserves comments and existing order", () => {
   const content = [
     "# workspace settings",
@@ -283,6 +309,87 @@ test("updatePnpmWorkspaceOverrides - removes nested entries as one block", () =>
   expect(parsePnpmWorkspaceOverrides(updated)).toEqual({ lodash: "4.17.21" });
 });
 
+test("updatePnpmWorkspaceOverrides - preserves unknown nested boundaries", () => {
+  const content = [
+    "overrides:",
+    "  foo:",
+    "    bar: 1.2.3",
+    "  invalid",
+    "  lodash: 4.17.20",
+    "",
+  ].join("\n");
+
+  const updated = updatePnpmWorkspaceOverrides(content, { lodash: "4.17.21" });
+
+  expect(updated).toContain("  invalid");
+  expect(updated).not.toContain("foo:");
+});
+
+test("updatePnpmWorkspaceOverrides - replaces malformed existing values", () => {
+  const content = "overrides:\n  foo: { bar }\n";
+
+  const updated = updatePnpmWorkspaceOverrides(content, { foo: "1.0.0" });
+
+  expect(parsePnpmWorkspaceOverrides(updated)).toEqual({ foo: "1.0.0" });
+});
+
+test("updatePnpmWorkspaceOverrides - converts flow sections to blocks", () => {
+  const content = "overrides: { lodash: 4.17.20 } # pins\n";
+
+  const updated = updatePnpmWorkspaceOverrides(content, { lodash: "4.17.21" });
+
+  expect(updated).toContain("overrides: # pins");
+  expect(parsePnpmWorkspaceOverrides(updated)).toEqual({ lodash: "4.17.21" });
+});
+
+test("updatePnpmWorkspaceOverrides - formats an emptied section", () => {
+  const updated = updatePnpmWorkspaceOverrides("overrides:\n  lodash: 4.17.20\n", {});
+
+  expect(updated).toBe("overrides: {}\n");
+});
+
+test("updatePnpmWorkspaceOverrides - appends a missing CRLF section", () => {
+  const updated = updatePnpmWorkspaceOverrides("packages:\r\n  - packages/*", {
+    lodash: "4.17.21",
+  });
+
+  expect(updated).toBe('packages:\r\n  - packages/*\r\noverrides:\r\n  "lodash": "4.17.21"\r\n');
+});
+
+test("updatePnpmWorkspaceOverrides - leaves missing empty sections unchanged", () => {
+  expect(updatePnpmWorkspaceOverrides("packages:\n", {})).toBe("packages:\n");
+});
+
+test("applyOverridesToSourceConfig - removes JSON override fields", () => {
+  const source = { packageManager: "pnpm", overrides: {} } as const;
+  const resolutions = { ...source, kind: "json", path: "pins.json", field: "resolutions" } as const;
+  const overrides = {
+    ...source,
+    kind: "manifest",
+    path: "package.json",
+    field: "overrides",
+  } as const;
+  const pnpm = { ...source, kind: "json", path: "pins.json", field: "pnpm" } as const;
+  const config = { name: "app", version: "1.0.0" };
+
+  expect(
+    applyOverridesToSourceConfig({ ...config, resolutions: { foo: "1" } }, resolutions, {}),
+  ).toEqual(config);
+  expect(
+    applyOverridesToSourceConfig({ ...config, overrides: { foo: "1" } }, overrides, {}),
+  ).toEqual(config);
+  expect(
+    applyOverridesToSourceConfig({ ...config, pnpm: { overrides: { foo: "1" } } }, pnpm, {}),
+  ).toEqual(config);
+  expect(
+    applyOverridesToSourceConfig(
+      { ...config, pnpm: { overrides: { foo: "1" }, packageExtensions: {} } },
+      pnpm,
+      {},
+    ),
+  ).toEqual({ ...config, pnpm: { packageExtensions: {} } });
+});
+
 test("resolveOverrideSource - selects pnpm-workspace.yaml for pnpm 11", () => {
   const root = mkdtempSync(join(tmpdir(), "pastoralist-overrides-"));
   const manifestPath = join(root, "package.json");
@@ -297,6 +404,24 @@ test("resolveOverrideSource - selects pnpm-workspace.yaml for pnpm 11", () => {
   const source = resolveOverrideSource({ config, manifestPath });
 
   expect(source.kind).toBe("yaml");
+  expect(source.overrides).toEqual({ lodash: "4.17.21" });
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("resolveOverrideSource - keeps pnpm 10 overrides in the manifest", () => {
+  const root = mkdtempSync(join(tmpdir(), "pastoralist-pnpm-10-"));
+  const manifestPath = join(root, "package.json");
+  const config: PastoralistJSON = {
+    name: "pnpm-project",
+    version: "1.0.0",
+    pnpm: { overrides: { lodash: "4.17.21" } },
+  };
+  writeFileSync(manifestPath, JSON.stringify(config));
+  writeFileSync(join(root, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+
+  const source = resolveOverrideSource({ config, manifestPath });
+
+  expect(source.kind).toBe("manifest");
   expect(source.overrides).toEqual({ lodash: "4.17.21" });
   rmSync(root, { recursive: true, force: true });
 });

--- a/tests/unit/core/security/index.test.ts
+++ b/tests/unit/core/security/index.test.ts
@@ -88,21 +88,26 @@ const createTempCacheDir = (name: string): string => {
   return dir;
 };
 
-const createExternalJsonAutoFixFixture = () => {
+const createExternalJsonAutoFixFixture = (hasManifestSource = true) => {
   const root = fs.mkdtempSync(path.join(tmpdir(), "pastoralist-json-autofix-"));
   const packagePath = path.join(root, "package.json");
   const overridePath = path.join(root, "overrides.json");
-  const packageJson = {
-    name: "external-overrides",
-    version: "1.0.0",
-    packageManager: "npm@11.0.0",
-    dependencies: { lodash: "4.17.20" },
-    pastoralist: { overrideSource: "overrides.json" },
-  };
+  const pastoralist = { overrideSource: "overrides.json" };
+  const packageJson = Object.assign(
+    {},
+    {
+      name: "external-overrides",
+      version: "1.0.0",
+      packageManager: "npm@11.0.0",
+      dependencies: { lodash: "4.17.20" },
+    },
+    hasManifestSource ? { pastoralist } : undefined,
+  );
   fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2));
   fs.writeFileSync(overridePath, JSON.stringify({ overrides: { axios: "1.8.0" } }, null, 2));
   const checker = new SecurityChecker({ provider: "osv", root });
-  return { root, packagePath, overridePath, checker };
+  const effectiveConfig = Object.assign({}, packageJson, { pastoralist });
+  return { root, packagePath, overridePath, checker, effectiveConfig };
 };
 
 test("Security Alert Detection - should identify vulnerable packages in dependencies", () => {
@@ -1148,6 +1153,42 @@ test("applyAutoFix - keeps external JSON overrides out of package.json", () => {
     expect(updatedPackage.overrides).toBeUndefined();
     expect(updatedPackage.pastoralist.appendix["lodash@4.17.21"]).toBeDefined();
     expect(updatedSource.overrides).toEqual({ axios: "1.8.0", lodash: "4.17.21" });
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("applyAutoFix - honors override sources from merged config", () => {
+  const fixture = createExternalJsonAutoFixFixture(false);
+
+  try {
+    fixture.checker.applyAutoFix(
+      [BASE_SECURITY_OVERRIDE],
+      fixture.packagePath,
+      fixture.effectiveConfig,
+    );
+    const updatedPackage = JSON.parse(fs.readFileSync(fixture.packagePath, "utf8"));
+    const updatedSource = JSON.parse(fs.readFileSync(fixture.overridePath, "utf8"));
+    expect(updatedPackage.overrides).toBeUndefined();
+    expect(updatedSource.overrides).toEqual({ axios: "1.8.0", lodash: "4.17.21" });
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("rollbackAutoFix - restores package and external override source", () => {
+  const fixture = createExternalJsonAutoFixFixture();
+  const originalPackage = fs.readFileSync(fixture.packagePath, "utf8");
+  const originalSource = fs.readFileSync(fixture.overridePath, "utf8");
+
+  try {
+    const backupPath = fixture.checker.applyAutoFix(
+      [BASE_SECURITY_OVERRIDE],
+      fixture.packagePath,
+    ) as string;
+    fixture.checker.rollbackAutoFix(backupPath, fixture.packagePath);
+    expect(fs.readFileSync(fixture.packagePath, "utf8")).toBe(originalPackage);
+    expect(fs.readFileSync(fixture.overridePath, "utf8")).toBe(originalSource);
   } finally {
     fs.rmSync(fixture.root, { recursive: true, force: true });
   }

--- a/tests/unit/core/security/index.test.ts
+++ b/tests/unit/core/security/index.test.ts
@@ -88,11 +88,14 @@ const createTempCacheDir = (name: string): string => {
   return dir;
 };
 
-const createExternalJsonAutoFixFixture = (hasManifestSource = true) => {
+const createExternalJsonAutoFixFixture = (
+  hasManifestSource = true,
+  overrideSource = "overrides.json",
+) => {
   const root = fs.mkdtempSync(path.join(tmpdir(), "pastoralist-json-autofix-"));
   const packagePath = path.join(root, "package.json");
-  const overridePath = path.join(root, "overrides.json");
-  const pastoralist = { overrideSource: "overrides.json" };
+  const overridePath = path.join(root, overrideSource);
+  const pastoralist = { overrideSource };
   const packageJson = Object.assign(
     {},
     {
@@ -103,6 +106,7 @@ const createExternalJsonAutoFixFixture = (hasManifestSource = true) => {
     },
     hasManifestSource ? { pastoralist } : undefined,
   );
+  fs.mkdirSync(path.dirname(overridePath), { recursive: true });
   fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2));
   fs.writeFileSync(overridePath, JSON.stringify({ overrides: { axios: "1.8.0" } }, null, 2));
   const checker = new SecurityChecker({ provider: "osv", root });
@@ -1176,10 +1180,11 @@ test("applyAutoFix - honors override sources from merged config", () => {
   }
 });
 
-test("rollbackAutoFix - restores package and external override source", () => {
-  const fixture = createExternalJsonAutoFixFixture();
+test("rollbackAutoFix - restores same-basename package and override sources", () => {
+  const fixture = createExternalJsonAutoFixFixture(true, "config/package.json");
   const originalPackage = fs.readFileSync(fixture.packagePath, "utf8");
   const originalSource = fs.readFileSync(fixture.overridePath, "utf8");
+  const nowSpy = spyOn(Date, "now").mockReturnValue(1_786_310_000_000);
 
   try {
     const backupPath = fixture.checker.applyAutoFix(
@@ -1190,6 +1195,7 @@ test("rollbackAutoFix - restores package and external override source", () => {
     expect(fs.readFileSync(fixture.packagePath, "utf8")).toBe(originalPackage);
     expect(fs.readFileSync(fixture.overridePath, "utf8")).toBe(originalSource);
   } finally {
+    nowSpy.mockRestore();
     fs.rmSync(fixture.root, { recursive: true, force: true });
   }
 });

--- a/tests/unit/core/security/index.test.ts
+++ b/tests/unit/core/security/index.test.ts
@@ -1154,6 +1154,47 @@ test("applyAutoFix - should apply security overrides to package.json", async () 
   mockConsoleLog.mockRestore();
 });
 
+test("applyAutoFix - should write pnpm 11 overrides to the workspace manifest", async () => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), "pastoralist-pnpm-autofix-"));
+  const packagePath = path.join(root, "package.json");
+  const workspacePath = path.join(root, "pnpm-workspace.yaml");
+  const packageJson = {
+    name: "pnpm-project",
+    version: "1.0.0",
+    packageManager: "pnpm@11.0.0",
+    dependencies: { lodash: "4.17.20" },
+  };
+  fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2));
+  fs.writeFileSync(workspacePath, '# retained\noverrides:\n  axios: "1.8.0"\n');
+  const checker = new SecurityChecker({ provider: "osv", root });
+
+  try {
+    checker.applyAutoFix(
+      [
+        {
+          packageName: "lodash",
+          fromVersion: "4.17.20",
+          toVersion: "4.17.21",
+          reason: "Security fix",
+          severity: "high",
+        },
+      ],
+      packagePath,
+    );
+
+    const updatedPackage = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+    const updatedWorkspace = fs.readFileSync(workspacePath, "utf8");
+    expect(updatedPackage.pnpm).toBeUndefined();
+    expect(updatedPackage.overrides).toBeUndefined();
+    expect(updatedPackage.pastoralist.appendix["lodash@4.17.21"]).toBeDefined();
+    expect(updatedWorkspace).toContain("# retained");
+    expect(updatedWorkspace).toContain('axios: "1.8.0"');
+    expect(updatedWorkspace).toContain('"lodash": "4.17.21"');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("applyAutoFix - should throw error when package.json not found", async () => {
   const checker = new SecurityChecker({ provider: "osv" });
   const overrides = [

--- a/tests/unit/core/security/index.test.ts
+++ b/tests/unit/core/security/index.test.ts
@@ -88,6 +88,23 @@ const createTempCacheDir = (name: string): string => {
   return dir;
 };
 
+const createExternalJsonAutoFixFixture = () => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), "pastoralist-json-autofix-"));
+  const packagePath = path.join(root, "package.json");
+  const overridePath = path.join(root, "overrides.json");
+  const packageJson = {
+    name: "external-overrides",
+    version: "1.0.0",
+    packageManager: "npm@11.0.0",
+    dependencies: { lodash: "4.17.20" },
+    pastoralist: { overrideSource: "overrides.json" },
+  };
+  fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2));
+  fs.writeFileSync(overridePath, JSON.stringify({ overrides: { axios: "1.8.0" } }, null, 2));
+  const checker = new SecurityChecker({ provider: "osv", root });
+  return { root, packagePath, overridePath, checker };
+};
+
 test("Security Alert Detection - should identify vulnerable packages in dependencies", () => {
   const checker = new SecurityChecker({ debug: false });
   const provider = new GitHubSecurityProvider({ debug: false });
@@ -984,81 +1001,6 @@ test("isNewVulnerability - Set key format matches packageName@currentVersion", (
   expect(result2).toBe(true);
 });
 
-test("getOverrideField - should return resolutions for yarn", () => {
-  const checker = new SecurityChecker({ provider: "osv" });
-  const result = (checker as any).getOverrideField("yarn");
-
-  expect(result).toBe("resolutions");
-});
-
-test("getOverrideField - should return overrides for npm", () => {
-  const checker = new SecurityChecker({ provider: "osv" });
-  const result = (checker as any).getOverrideField("npm");
-
-  expect(result).toBe("overrides");
-});
-
-test("getOverrideField - should return overrides for pnpm", () => {
-  const checker = new SecurityChecker({ provider: "osv" });
-  const result = (checker as any).getOverrideField("pnpm");
-
-  expect(result).toBe("overrides");
-});
-
-test("getOverrideField - should return overrides for bun", () => {
-  const checker = new SecurityChecker({ provider: "osv" });
-  const result = (checker as any).getOverrideField("bun");
-
-  expect(result).toBe("overrides");
-});
-
-test("applyOverridesToPackageJson - should apply overrides for npm", () => {
-  const checker = new SecurityChecker({ provider: "osv" });
-  const packageJson = { name: "test", version: "1.0.0" };
-  const newOverrides = { lodash: "4.17.21" };
-
-  const result = (checker as any).applyOverridesToPackageJson(packageJson, "npm", newOverrides);
-
-  expect(result.overrides).toEqual({ lodash: "4.17.21" });
-});
-
-test("applyOverridesToPackageJson - should apply resolutions for yarn", () => {
-  const checker = new SecurityChecker({ provider: "osv" });
-  const packageJson = { name: "test", version: "1.0.0" };
-  const newOverrides = { lodash: "4.17.21" };
-
-  const result = (checker as any).applyOverridesToPackageJson(packageJson, "yarn", newOverrides);
-
-  expect(result.resolutions).toEqual({ lodash: "4.17.21" });
-});
-
-test("applyOverridesToPackageJson - should apply pnpm overrides", () => {
-  const checker = new SecurityChecker({ provider: "osv" });
-  const packageJson = { name: "test", version: "1.0.0" };
-  const newOverrides = { lodash: "4.17.21" };
-
-  const result = (checker as any).applyOverridesToPackageJson(packageJson, "pnpm", newOverrides);
-
-  expect(result.pnpm.overrides).toEqual({ lodash: "4.17.21" });
-});
-
-test("applyOverridesToPackageJson - should merge with existing overrides", () => {
-  const checker = new SecurityChecker({ provider: "osv" });
-  const packageJson = {
-    name: "test",
-    version: "1.0.0",
-    overrides: { axios: "1.0.0" },
-  };
-  const newOverrides = { lodash: "4.17.21" };
-
-  const result = (checker as any).applyOverridesToPackageJson(packageJson, "npm", newOverrides);
-
-  expect(result.overrides).toEqual({
-    axios: "1.0.0",
-    lodash: "4.17.21",
-  });
-});
-
 test("createBackup - should create backup file", () => {
   const checker = new SecurityChecker({ provider: "osv" });
   const testDir = fs.mkdtempSync(path.join(tmpdir(), "pastoralist-backup-"));
@@ -1192,6 +1134,22 @@ test("applyAutoFix - should write pnpm 11 overrides to the workspace manifest", 
     expect(updatedWorkspace).toContain('"lodash": "4.17.21"');
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("applyAutoFix - keeps external JSON overrides out of package.json", () => {
+  const fixture = createExternalJsonAutoFixFixture();
+
+  try {
+    fixture.checker.applyAutoFix([BASE_SECURITY_OVERRIDE], fixture.packagePath);
+
+    const updatedPackage = JSON.parse(fs.readFileSync(fixture.packagePath, "utf8"));
+    const updatedSource = JSON.parse(fs.readFileSync(fixture.overridePath, "utf8"));
+    expect(updatedPackage.overrides).toBeUndefined();
+    expect(updatedPackage.pastoralist.appendix["lodash@4.17.21"]).toBeDefined();
+    expect(updatedSource.overrides).toEqual({ axios: "1.8.0", lodash: "4.17.21" });
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
   }
 });
 

--- a/tests/unit/core/update/utils.test.ts
+++ b/tests/unit/core/update/utils.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, mock } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -20,6 +20,25 @@ import type {
   WriteResultContext,
 } from "../../../../src/types";
 import type { PastoralistConfig } from "../../../../src/config";
+
+const createExternalAppendixFixture = () => {
+  const root = mkdtempSync(join(tmpdir(), "pastoralist-write-result-"));
+  const path = join(root, "package.json");
+  const appendixPath = join(root, "ledger.json");
+  const appendix = { "lodash@4.17.21": { dependents: { app: "lodash@^4" } } };
+  const config = { name: "test", version: "1.0.0" };
+  writeFileSync(path, JSON.stringify(config));
+  const ctx: WriteResultContext = {
+    appendixTarget: { path: appendixPath },
+    path,
+    config,
+    finalAppendix: appendix,
+    finalOverrides: {},
+    options: { dryRun: false },
+    isTesting: false,
+  };
+  return { appendix, appendixPath, ctx, root };
+};
 
 test("determineProcessingMode - should return root mode when no depPaths", () => {
   const options: Options = {};
@@ -493,4 +512,13 @@ test("writeResult - should write result with no options", () => {
 
   writeResult(ctx);
   expect(ctx.config.name).toBe("test");
+});
+
+test("writeResult - writes an external appendix target", () => {
+  const { appendix, appendixPath, ctx, root } = createExternalAppendixFixture();
+
+  writeResult(ctx);
+
+  expect(JSON.parse(readFileSync(appendixPath, "utf8"))).toEqual({ appendix });
+  rmSync(root, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Proposed Changes

- Add pnpm 11+ workspace override support.
- Read and update block-style and flow-style YAML overrides without corrupting nested mappings.
- Support external JSON/YAML override sources and external JSON appendix targets.
- Keep security auto-fixes out of `package.json` when overrides are stored externally.
- Roll back every file changed by a security auto-fix.
- Preserve externally configured `compactAppendix` behavior.

## Example

Configure Pastoralist to keep pnpm overrides in `pnpm-workspace.yaml` and the appendix in a separate JSON file:

```json
{
  "name": "example-app",
  "version": "1.0.0",
  "packageManager": "pnpm@11.0.0",
  "pastoralist": {
    "overrideSource": "pnpm-workspace.yaml",
    "appendixSource": ".pastoralistrc.json"
  }
}
```

Both block-style and flow-style pnpm overrides are supported:

```yaml
packages:
  - packages/*

overrides:
  lodash: 4.17.21
  foo:
    bar: 1.2.3
```

```yaml
packages:
  - packages/*

overrides: { lodash: 4.17.21, foo: { bar: 1.2.3 } }
```

Pastoralist writes the dependency ledger to the configured appendix target instead of duplicating it in `package.json`:

```json
{
  "appendix": {
    "lodash@4.17.21": {
      "dependents": {
        "example-app": "lodash@^4.17.0"
      }
    }
  }
}
```

## Validation

- Codecov-equivalent project line coverage: 97.6552% (10495/10747)
- Changed executable lines: 100% covered locally
- Unit tests: 2069 passed, 1 skipped, 0 failed
- Docker e2e: npm, pnpm, and Yarn passed
