### PR TITLE
chore(release): v1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pastoralist",
-  "version": "1.12.16",
+  "version": "1.13.0",
   "description": "Audit, secure, and clean up package manager overrides for npm, pnpm, Yarn, and Bun.",
   "keywords": [
     "bun",


### PR DESCRIPTION
Release v1.13.0.

This PR was created by `bun run release`.
After checks pass, the release command merges this PR and pushes the version tag.